### PR TITLE
Various Temporary Fixes in the New Meter Wizard

### DIFF
--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -553,6 +553,7 @@ namespace SystemCenter.Controllers.OpenXDA
                         asset.ConnectionFactory = () => (new AdoDataConnection(Connection));
 
                         List<Channel> connectedChannels = asset.ConnectedChannels;
+                        connectedChannels.AddRange(asset.DirectChannels);
 
                         if (connectedChannels.Count > 0)
                         {

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Meters/OpenXDAMeterController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Meters/OpenXDAMeterController.cs
@@ -486,6 +486,36 @@ namespace SystemCenter.Controllers.OpenXDA
             
         }
 
+        [HttpPost, Route("{meterID:int}/Asset/{assetID:int}/{locationID:int}")]
+        public IHttpActionResult AddMeterAsset(int meterID, int assetID, int locationID)
+        {
+            if (PostRoles == string.Empty || User.IsInRole(PostRoles))
+            {
+                using (AdoDataConnection connection = new AdoDataConnection(Connection))
+                {
+                    try
+                    {
+                        MeterAsset meterAsset = new TableOperations<MeterAsset>(connection).QueryRecordWhere("MeterID = {0} AND AssetID = {1}", meterID, assetID);
+                        if (meterAsset is null) 
+                            new TableOperations<MeterAsset>(connection).AddNewRecord(new MeterAsset() { MeterID = meterID, AssetID = assetID});
+
+                        AssetLocation assetLoc = new TableOperations<AssetLocation>(connection).QueryRecordWhere("LocationID = {0} AND AssetID = {1}", locationID, assetID);
+                        if (assetLoc is null)
+                            new TableOperations<AssetLocation>(connection).AddNewRecord(new AssetLocation() { LocationID = locationID, AssetID = assetID });
+                     
+                        return Ok(1);
+                    }
+                    catch (Exception ex)
+                    {
+                        return InternalServerError(ex);
+                    }
+                }
+            }
+            else
+                return Unauthorized();
+
+        }
+
         [HttpGet, Route("extDataBases")]
         public IHttpActionResult GetExternalDB()
         {

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Meters/OpenXDAMeterController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Meters/OpenXDAMeterController.cs
@@ -78,147 +78,145 @@ namespace SystemCenter.Controllers.OpenXDA
         [HttpPost, Route("New")]
         public IHttpActionResult PostNewMeter([FromBody] JObject record)
         {
-            if (PostRoles == string.Empty || User.IsInRole(PostRoles))
+            if (PostRoles != string.Empty && !User.IsInRole(PostRoles))
+                return Unauthorized();
+            
+            try
             {
-                try
-                {
-                    Meter meter = record["MeterInfo"].ToObject<Meter>();
-                    Location location = record["LocationInfo"].ToObject<Location>();
+                Meter meter = record["MeterInfo"].ToObject<Meter>();
+                Location location = record["LocationInfo"].ToObject<Location>();
 
-                    using (TransactionScope scope = new TransactionScope())
+                using (TransactionScope scope = new TransactionScope())
+                {
+                    using (AdoDataConnection connection = new AdoDataConnection(Connection))
                     {
-                        using (AdoDataConnection connection = new AdoDataConnection(Connection))
+                        if (location.ID == 0)
+                            (new TableOperations<Location>(connection)).AddNewRecord(location);
+
+                        JToken Assets = record["Assets"];
+                        int locationID = connection.ExecuteScalar<int>($"SELECT ID FROM Location WHERE LocationKey = '{location.LocationKey}'");
+                        meter.LocationID = locationID;
+
+                        (new TableOperations<Meter>(connection)).AddNewRecord(meter);
+                        int meterId = connection.ExecuteScalar<int>($"SELECT ID FROM Meter WHERE AssetKey = '{meter.AssetKey}'");
+
+                        foreach (var asset in Assets)
                         {
-                            if (location.ID == 0)
-                                (new TableOperations<Location>(connection)).AddNewRecord(location);
-
-                            JToken Assets = record["Assets"];
-                            int locationID = connection.ExecuteScalar<int>($"SELECT ID FROM Location WHERE LocationKey = '{location.LocationKey}'");
-                            meter.LocationID = locationID;
-
-                            (new TableOperations<Meter>(connection)).AddNewRecord(meter);
-                            int meterId = connection.ExecuteScalar<int>($"SELECT ID FROM Meter WHERE AssetKey = '{meter.AssetKey}'");
-
-                            foreach (var asset in Assets)
+                            string assetType = asset["AssetType"].ToString();
+                            if (asset["ID"].ToString() == "0")
                             {
-                                string assetType = asset["AssetType"].ToString();
-                                if (asset["ID"].ToString() == "0")
+                                if (assetType == "Line")
+                                    (new TableOperations<Line>(connection)).AddNewRecord(asset.ToObject<Line>());
+                                else if (assetType == "LineSegment")
+                                    (new TableOperations<LineSegment>(connection)).AddNewRecord(asset.ToObject<LineSegment>());
+                                else if (assetType == "Breaker")
                                 {
-                                    if (assetType == "Line")
-                                        (new TableOperations<Line>(connection)).AddNewRecord(asset.ToObject<Line>());
-                                    else if (assetType == "LineSegment")
-                                        (new TableOperations<LineSegment>(connection)).AddNewRecord(asset.ToObject<LineSegment>());
-                                    else if (assetType == "Breaker")
-                                    {
-                                        (new TableOperations<Breaker>(connection)).AddNewRecord(asset.ToObject<Breaker>());
-                                        if (asset["EDNAPoint"] != null)
-                                            connection.ExecuteNonQuery($"INSERT INTO EDNAPoint (BreakerID, Point) VALUES ((SELECT ID FROM Asset WHERE AssetKey = '{asset["AssetKey"].ToString()}'),'{asset["EDNAPoint"].ToString()}')");
-                                    }
-                                    else if (assetType == "Bus")
-                                        (new TableOperations<Bus>(connection)).AddNewRecord(asset.ToObject<Bus>());
-                                    else if (assetType == "CapacitorBank")
-                                        (new TableOperations<CapBank>(connection)).AddNewRecord(asset.ToObject<CapBank>());
-                                    else if (assetType == "Transformer")
-                                        (new TableOperations<Transformer>(connection)).AddNewRecord(asset.ToObject<Transformer>());
-                                    else if (assetType == "CapacitorBankRelay")
-                                        (new TableOperations<CapBankRelay>(connection)).AddNewRecord(asset.ToObject<CapBankRelay>());
-                                    else if (assetType == "DER")
-                                        (new TableOperations<DER>(connection)).AddNewRecord(asset.ToObject<DER>());
-
-                                    else
-                                        (new TableOperations<Asset>(connection)).AddNewRecord(asset.ToObject<Asset>());
+                                    (new TableOperations<Breaker>(connection)).AddNewRecord(asset.ToObject<Breaker>());
+                                    if (asset["EDNAPoint"] != null)
+                                        connection.ExecuteNonQuery($"INSERT INTO EDNAPoint (BreakerID, Point) VALUES ((SELECT ID FROM Asset WHERE AssetKey = '{asset["AssetKey"].ToString()}'),'{asset["EDNAPoint"].ToString()}')");
                                 }
-                                int assetID = connection.ExecuteScalar<int>($"SELECT ID FROM Asset WHERE AssetKey = '{asset["AssetKey"].ToString()}'");
+                                else if (assetType == "Bus")
+                                    (new TableOperations<Bus>(connection)).AddNewRecord(asset.ToObject<Bus>());
+                                else if (assetType == "CapacitorBank")
+                                    (new TableOperations<CapBank>(connection)).AddNewRecord(asset.ToObject<CapBank>());
+                                else if (assetType == "Transformer")
+                                    (new TableOperations<Transformer>(connection)).AddNewRecord(asset.ToObject<Transformer>());
+                                else if (assetType == "CapacitorBankRelay")
+                                    (new TableOperations<CapBankRelay>(connection)).AddNewRecord(asset.ToObject<CapBankRelay>());
+                                else if (assetType == "DER")
+                                    (new TableOperations<DER>(connection)).AddNewRecord(asset.ToObject<DER>());
 
-                                (new TableOperations<MeterAsset>(connection)).AddNewRecord(new MeterAsset()
-                                {
-                                    AssetID = assetID,
-                                    MeterID = meterId
-                                });
-                                (new TableOperations<AssetLocation>(connection)).AddNewRecord(new AssetLocation()
-                                {
-                                    AssetID = assetID,
-                                    LocationID = locationID
-                                });
+                                else
+                                    (new TableOperations<Asset>(connection)).AddNewRecord(asset.ToObject<Asset>());
                             }
+                            int assetID = connection.ExecuteScalar<int>($"SELECT ID FROM Asset WHERE AssetKey = '{asset["AssetKey"].ToString()}'");
 
-                            JToken AssetConnections = record["AssetConnections"];
-                            foreach (var assetConnection in AssetConnections)
+                            (new TableOperations<MeterAsset>(connection)).AddNewRecord(new MeterAsset()
                             {
-                                int childID = connection.ExecuteScalar<int>($"SELECT ID From asset WHERE AssetKey = '{assetConnection["Child"].ToString()}'");
-                                int parentID = connection.ExecuteScalar<int>($"SELECT ID From asset WHERE AssetKey = '{assetConnection["Parent"].ToString()}'");
-                                (new TableOperations<AssetConnection>(connection)).AddNewRecord(new AssetConnection()
-                                {
-                                    ParentID = parentID,
-                                    ChildID = childID,
-                                    AssetRelationshipTypeID = int.Parse(assetConnection["AssetRelationshipTypeID"].ToString())
-                                });
-                            }
-
-                            JToken Channels = record["Channels"];
-                            foreach (var channel in Channels)
+                                AssetID = assetID,
+                                MeterID = meterId
+                            });
+                            (new TableOperations<AssetLocation>(connection)).AddNewRecord(new AssetLocation()
                             {
-                                string assetKey = channel["Asset"].ToString();
-                                string measurementType = channel["MeasurementType"].ToString();
-                                string measurementcharacteristic = channel["MeasurementCharacteristic"].ToString();
-                                string phase = channel["Phase"].ToString();
-                                string name = channel["Name"].ToString();
-                                double adder = channel["Adder"].ToObject<double>();
-                                double multiplier = channel["Multiplier"].ToObject<double>();
-                                string description = channel["Description"].ToString() == string.Empty ? "NULL" : "'" + channel["Description"].ToString() + "'";
-                                int conPriority = channel["ConnectionPriority"].ToObject<int>();
-
-                                JToken Series = channel["Series"];
-                                string sourceIndex = Series[0]["SourceIndexes"].ToString();
-                                if (assetKey == string.Empty) continue;
-
-                                Phase ph = new TableOperations<Phase>(connection).QueryRecordWhere("Name = {0}", phase);
-                                if(ph == null)
-                                {
-                                    ph = new Phase() {ID=0, Name = phase, Description = phase };
-                                    new TableOperations<Phase>(connection).AddNewRecord(ph);
-                                }
-                                    
-                                connection.ExecuteNonQuery($@"INSERT INTO Channel
-                                    (
-                                        AssetID,
-                                        MeasurementTypeID,
-                                        MeterID,
-                                        MeasurementCharacteristicID,   
-                                        PhaseID,
-                                        Name,
-                                        Adder,
-                                        Multiplier,
-                                        SamplesPerHour,
-                                        HarmonicGroup,
-                                        Description,
-                                        Enabled,
-                                        ConnectionPriority
-                                    ) VALUES 
-                                ((SELECT ID FROM Asset WHERE AssetKey = '{assetKey}'),
-                                (SELECT ID FROM MeasurementType WHERE Name = '{measurementType}'),
-                                {meterId},
-                                (SELECT ID FROM MeasurementCharacteristic WHERE Name = '{measurementcharacteristic}'),
-                                (SELECT ID FROM Phase WHERE Name = '{phase}'),
-                                '{name}', {adder}, {multiplier}, 0,0,{description}, 1,{conPriority} )");
-
-                                connection.ExecuteNonQuery($@"INSERT INTO Series (ChannelID, SeriesTypeID, SourceIndexes) VALUES 
-                                    ((SELECT @@Identity), (SELECT ID FROM SeriesType WHERE Name = 'Values'), '{sourceIndex}') ");
-                            }
-
-                            scope.Complete();
+                                AssetID = assetID,
+                                LocationID = locationID
+                            });
                         }
-                    }                
 
-                    return Ok("Completed without errors.");
-                }
-                catch (Exception ex)
-                {
-                    return InternalServerError(ex);
-                }
+                        JToken AssetConnections = record["AssetConnections"];
+                        foreach (var assetConnection in AssetConnections)
+                        {
+                            int childID = connection.ExecuteScalar<int>($"SELECT ID From asset WHERE AssetKey = '{assetConnection["Child"].ToString()}'");
+                            int parentID = connection.ExecuteScalar<int>($"SELECT ID From asset WHERE AssetKey = '{assetConnection["Parent"].ToString()}'");
+                            (new TableOperations<AssetConnection>(connection)).AddNewRecord(new AssetConnection()
+                            {
+                                ParentID = parentID,
+                                ChildID = childID,
+                                AssetRelationshipTypeID = int.Parse(assetConnection["AssetRelationshipTypeID"].ToString())
+                            });
+                        }
+
+                        JToken Channels = record["Channels"];
+                        foreach (var channel in Channels)
+                        {
+                            string assetKey = channel["Asset"].ToString();
+                            string measurementType = channel["MeasurementType"].ToString();
+                            string measurementcharacteristic = channel["MeasurementCharacteristic"].ToString();
+                            string phase = channel["Phase"].ToString();
+                            string name = channel["Name"].ToString();
+                            double adder = channel["Adder"].ToObject<double>();
+                            double multiplier = channel["Multiplier"].ToObject<double>();
+                            string description = channel["Description"].ToString() == string.Empty ? "NULL" : "'" + channel["Description"].ToString() + "'";
+                            int conPriority = channel["ConnectionPriority"].ToObject<int>();
+
+                            JToken Series = channel["Series"];
+                            string sourceIndex = Series[0]["SourceIndexes"].ToString();
+                            if (assetKey == string.Empty) continue;
+
+                            Phase ph = new TableOperations<Phase>(connection).QueryRecordWhere("Name = {0}", phase);
+                            if(ph == null)
+                            {
+                                ph = new Phase() {ID=0, Name = phase, Description = phase };
+                                new TableOperations<Phase>(connection).AddNewRecord(ph);
+                            }
+                                
+                            connection.ExecuteNonQuery($@"INSERT INTO Channel
+                                (
+                                    AssetID,
+                                    MeasurementTypeID,
+                                    MeterID,
+                                    MeasurementCharacteristicID,   
+                                    PhaseID,
+                                    Name,
+                                    Adder,
+                                    Multiplier,
+                                    SamplesPerHour,
+                                    HarmonicGroup,
+                                    Description,
+                                    Enabled,
+                                    ConnectionPriority
+                                ) VALUES 
+                            ((SELECT ID FROM Asset WHERE AssetKey = '{assetKey}'),
+                            (SELECT ID FROM MeasurementType WHERE Name = '{measurementType}'),
+                            {meterId},
+                            (SELECT ID FROM MeasurementCharacteristic WHERE Name = '{measurementcharacteristic}'),
+                            (SELECT ID FROM Phase WHERE Name = '{phase}'),
+                            '{name}', {adder}, {multiplier}, 0,0,{description}, 1,{conPriority} )");
+
+                            connection.ExecuteNonQuery($@"INSERT INTO Series (ChannelID, SeriesTypeID, SourceIndexes) VALUES 
+                                ((SELECT @@Identity), (SELECT ID FROM SeriesType WHERE Name = 'Values'), '{sourceIndex}') ");
+                        }
+
+                        scope.Complete();
+                    }
+                }                
+
+                return Ok("Completed without errors.");
             }
-            return
-                Unauthorized();
+            catch (Exception ex)
+            {
+                return InternalServerError(ex);
+            }        
         }
 
         /*
@@ -227,292 +225,286 @@ namespace SystemCenter.Controllers.OpenXDA
         [HttpPost, Route("{meterID:int}/Channel/Update/{filter=All}")]
         public IHttpActionResult UpdateMeterChannels([FromBody] JObject postData, int meterID, string filter)
         {
-            if (PatchRoles == string.Empty || User.IsInRole(PatchRoles))
+            if (PatchRoles != string.Empty && !User.IsInRole(PatchRoles))
+                return Unauthorized();
+            
+            try
             {
-                try
+                using (AdoDataConnection connection = new AdoDataConnection(Connection))
                 {
-                    using (AdoDataConnection connection = new AdoDataConnection(Connection))
+                    TableOperations<Channel> channelTable = new TableOperations<Channel>(connection);
+                    TableOperations<Series> seriesTable = new TableOperations<Series>(connection);
+
+                    JToken Channels = postData["Channels"];
+                    IEnumerable<MeasurementType> measurementTypes = new TableOperations<MeasurementType>(connection).QueryRecords();
+                    IEnumerable<MeasurementCharacteristic> measurementCharacteristics = new TableOperations<MeasurementCharacteristic>(connection).QueryRecords();
+                    IEnumerable<Phase> phases = new TableOperations<Phase>(connection).QueryRecords();
+                    IEnumerable<Asset> assets = new TableOperations<Asset>(connection).QueryRecordsWhere("ID IN (SELECT AssetID FROM MeterAsset WHERE MeterID = {0})", meterID);
+                    IEnumerable<SeriesType> seriesTypes = new TableOperations<SeriesType>(connection).QueryRecords();
+                    List<int> channelIDs = new List<int>();
+
+                    foreach (JToken channelToken in Channels)
                     {
-                        TableOperations<Channel> channelTable = new TableOperations<Channel>(connection);
-                        TableOperations<Series> seriesTable = new TableOperations<Series>(connection);
+                        Channel channel = new Channel();
+                        channel.ID = channelToken["ID"].ToObject<int>();
+                        channel.MeterID = meterID;
+                        channel.AssetID = assets.FirstOrDefault(asset => asset.AssetKey == channelToken["Asset"].ToString()).ID;
+                        channel.MeasurementTypeID = measurementTypes.First(mt => mt.Name == channelToken["MeasurementType"].ToString()).ID;
+                        channel.MeasurementCharacteristicID = measurementCharacteristics.First(mc => mc.Name == channelToken["MeasurementCharacteristic"].ToString()).ID;
+                        channel.PhaseID = phases.First(phase => phase.Name == channelToken["Phase"].ToString()).ID;
+                        channel.Name = channelToken["Name"].ToString();
+                        channel.Description = channelToken["Description"].ToString() == string.Empty ? null : channelToken["Description"].ToString();
+                        channel.Adder = channelToken["Adder"].ToObject<double>();
+                        channel.Multiplier = channelToken["Multiplier"].ToObject<double>();
+                        channel.SamplesPerHour = channelToken["SamplesPerHour"].ToObject<double>();
+                        channel.PerUnitValue = channelToken["PerUnitValue"].ToObject<double?>();
+                        channel.HarmonicGroup = channelToken["HarmonicGroup"].ToObject<int>();
+                        channel.Enabled = channelToken["Enabled"].ToObject<bool>();
+                        channel.ConnectionPriority = channelToken["ConnectionPriority"].ToObject<int>();
+                        if (channel.AssetID == 0)
+                            continue;
 
-                        JToken Channels = postData["Channels"];
-                        IEnumerable<MeasurementType> measurementTypes = new TableOperations<MeasurementType>(connection).QueryRecords();
-                        IEnumerable<MeasurementCharacteristic> measurementCharacteristics = new TableOperations<MeasurementCharacteristic>(connection).QueryRecords();
-                        IEnumerable<Phase> phases = new TableOperations<Phase>(connection).QueryRecords();
-                        IEnumerable<Asset> assets = new TableOperations<Asset>(connection).QueryRecordsWhere("ID IN (SELECT AssetID FROM MeterAsset WHERE MeterID = {0})", meterID);
-                        IEnumerable<SeriesType> seriesTypes = new TableOperations<SeriesType>(connection).QueryRecords();
-                        List<int> channelIDs = new List<int>();
+                        channelTable.AddNewOrUpdateRecord(channel);
 
-                        foreach (JToken channelToken in Channels)
+                        if (channel.ID == 0)
+                            channel.ID = connection.ExecuteScalar<int>("SELECT @@IDENTITY");
+
+                        if (channelToken["Series"] is JArray array)
                         {
-                            Channel channel = new Channel();
-                            channel.ID = channelToken["ID"].ToObject<int>();
-                            channel.MeterID = meterID;
-                            channel.AssetID = assets.FirstOrDefault(asset => asset.AssetKey == channelToken["Asset"].ToString()).ID;
-                            channel.MeasurementTypeID = measurementTypes.First(mt => mt.Name == channelToken["MeasurementType"].ToString()).ID;
-                            channel.MeasurementCharacteristicID = measurementCharacteristics.First(mc => mc.Name == channelToken["MeasurementCharacteristic"].ToString()).ID;
-                            channel.PhaseID = phases.First(phase => phase.Name == channelToken["Phase"].ToString()).ID;
-                            channel.Name = channelToken["Name"].ToString();
-                            channel.Description = channelToken["Description"].ToString() == string.Empty ? null : channelToken["Description"].ToString();
-                            channel.Adder = channelToken["Adder"].ToObject<double>();
-                            channel.Multiplier = channelToken["Multiplier"].ToObject<double>();
-                            channel.SamplesPerHour = channelToken["SamplesPerHour"].ToObject<double>();
-                            channel.PerUnitValue = channelToken["PerUnitValue"].ToObject<double?>();
-                            channel.HarmonicGroup = channelToken["HarmonicGroup"].ToObject<int>();
-                            channel.Enabled = channelToken["Enabled"].ToObject<bool>();
-                            channel.ConnectionPriority = channelToken["ConnectionPriority"].ToObject<int>();
-                            if (channel.AssetID == 0)
-                                continue;
-
-                            channelTable.AddNewOrUpdateRecord(channel);
-
-                            if (channel.ID == 0)
-                                channel.ID = connection.ExecuteScalar<int>("SELECT @@IDENTITY");
-
-                            if (channelToken["Series"] is JArray array)
+                            foreach (JToken seriesToken in array)
                             {
-                                foreach (JToken seriesToken in array)
-                                {
-                                    Series series = new Series();
-                                    series.ID = seriesToken.Value<int>("ID");
-                                    series.ChannelID = channel.ID;
-                                    series.SeriesTypeID = seriesTypes.First(st => st.Name == seriesToken.Value<string>("SeriesType")).ID;
-                                    series.SourceIndexes = seriesToken.Value<string>("SourceIndexes");
-                                    seriesTable.AddNewOrUpdateRecord(series);
-                                }
-                            }
-
-                            channelIDs.Add(channel.ID);
-                        }
-
-                        const string EventChannelFilter =
-                            "MeasurementCharacteristicID = (SELECT ID FROM MeasurementCharacteristic WHERE Name = 'Instantaneous') AND " +
-                            "(SELECT COUNT(*) FROM Series WHERE ChannelID = Channel.ID) = 1 AND " +
-                            "EXISTS (SELECT * FROM Series WHERE SeriesTypeID IN (SELECT ID FROM SeriesType WHERE Name IN ('Values', 'Instantaneous')))";
-
-                        string GetTypeFilter()
-                        {
-                            switch (filter.ToLower())
-                            {
-                                case "event": return EventChannelFilter;
-                                case "trend": return $"NOT ({EventChannelFilter})";
-                                case "none": return "1 IS NULL";
-                                default: return "1=1";
+                                Series series = new Series();
+                                series.ID = seriesToken.Value<int>("ID");
+                                series.ChannelID = channel.ID;
+                                series.SeriesTypeID = seriesTypes.First(st => st.Name == seriesToken.Value<string>("SeriesType")).ID;
+                                series.SourceIndexes = seriesToken.Value<string>("SourceIndexes");
+                                seriesTable.AddNewOrUpdateRecord(series);
                             }
                         }
 
-                        string idFilter = channelIDs.Any()
-                            ? $"ID NOT IN ({string.Join(",", channelIDs)})"
-                            : "1=1";
-
-                        string deleteFilter =
-                            $"MeterID = {meterID} AND " +
-                            $"({GetTypeFilter()}) AND " +
-                            $"{idFilter}";
-
-                        connection.ExecuteNonQuery("EXEC UniversalCascadeDelete 'Channel', {0}", deleteFilter);
-
-                        return Ok("Completed without errors");
+                        channelIDs.Add(channel.ID);
                     }
-                }
-                catch (Exception ex)
-                {
-                    return InternalServerError(ex);
+
+                    const string EventChannelFilter =
+                        "MeasurementCharacteristicID = (SELECT ID FROM MeasurementCharacteristic WHERE Name = 'Instantaneous') AND " +
+                        "(SELECT COUNT(*) FROM Series WHERE ChannelID = Channel.ID) = 1 AND " +
+                        "EXISTS (SELECT * FROM Series WHERE SeriesTypeID IN (SELECT ID FROM SeriesType WHERE Name IN ('Values', 'Instantaneous')))";
+
+                    string GetTypeFilter()
+                    {
+                        switch (filter.ToLower())
+                        {
+                            case "event": return EventChannelFilter;
+                            case "trend": return $"NOT ({EventChannelFilter})";
+                            case "none": return "1 IS NULL";
+                            default: return "1=1";
+                        }
+                    }
+
+                    string idFilter = channelIDs.Any()
+                        ? $"ID NOT IN ({string.Join(",", channelIDs)})"
+                        : "1=1";
+
+                    string deleteFilter =
+                        $"MeterID = {meterID} AND " +
+                        $"({GetTypeFilter()}) AND " +
+                        $"{idFilter}";
+
+                    connection.ExecuteNonQuery("EXEC UniversalCascadeDelete 'Channel', {0}", deleteFilter);
+
+                    return Ok("Completed without errors");
                 }
             }
-            else
-                return Unauthorized();
+            catch (Exception ex)
+            {
+                return InternalServerError(ex);
+            }
+            
         }
 
         [HttpGet, Route("{meterID:int}/Channels/{filter=All}")]
         public IHttpActionResult GetMeterChannels(int meterID, string filter)
         {
-            if (GetRoles == string.Empty || User.IsInRole(GetRoles))
-            {
-                const string ChannelQuery =
-                "SELECT " +
-                "    Channel.ID, " +
-                "    Meter.AssetKey AS Meter, " +
-                "    Asset.AssetKey AS Asset, " +
-                "    MeasurementType.Name AS MeasurementType, " +
-                "    MeasurementCharacteristic.Name AS MeasurementCharacteristic, " +
-                "    Phase.Name AS Phase, " +
-                "    Channel.Name, " +
-                "    Channel.Adder, " +
-                "    Channel.Multiplier, " +
-                "    Channel.SamplesPerHour, " +
-                "    Channel.PerUnitValue, " +
-                "    Channel.HarmonicGroup, " +
-                "    Channel.Description, " +
-                "    Channel.Enabled, " +
-                "    Channel.ConnectionPriority " +
-                "FROM " +
-                "    Channel JOIN " +
-                "    Asset ON Channel.AssetID = Asset.ID JOIN " +
-                "    Meter ON Channel.MeterID = Meter.ID JOIN " +
-                "    MeasurementType ON Channel.MeasurementTypeID = MeasurementType.ID JOIN " +
-                "    MeasurementCharacteristic ON Channel.MeasurementCharacteristicID = MeasurementCharacteristic.ID JOIN " +
-                "    Phase ON Channel.PhaseID = Phase.ID " +
-                "WHERE MeterID = {0}";
-
-                const string SeriesQuery =
-                    "SELECT " +
-                    "    Series.ID, " +
-                    "    Series.ChannelID, " +
-                    "    SeriesType.Name AS SeriesType, " +
-                    "    Series.SourceIndexes " +
-                    "FROM " +
-                    "    Series JOIN " +
-                    "    SeriesType ON Series.SeriesTypeID = SeriesType.ID JOIN " +
-                    "    Channel ON Series.ChannelID = Channel.ID " +
-                    "WHERE Channel.MeterID = {0}";
-
-            using (AdoDataConnection connection = new AdoDataConnection(Connection))
-            {
-                DataTable channelTable = connection.RetrieveData(ChannelQuery, meterID);
-                string channelJSON = JsonConvert.SerializeObject(channelTable);
-                JArray channelArray = JArray.Parse(channelJSON);
-
-                    DataTable seriesTable = connection.RetrieveData(SeriesQuery, meterID);
-                    string seriesJSON = JsonConvert.SerializeObject(seriesTable);
-                    JArray seriesArray = JArray.Parse(seriesJSON);
-
-                    int GetChannelID(JToken channel) => channel.Value<int>("ID");
-                    int GetSeriesChannelID(JToken series) => series.Value<int>("ChannelID");
-
-                    var groupings = channelArray
-                        .GroupJoin(seriesArray, GetChannelID, GetSeriesChannelID, (Channel, Series) => new { Channel, Series });
-
-                    foreach (var grouping in groupings)
-                        grouping.Channel["Series"] = new JArray(grouping.Series);
-
-                    bool IsInstantaneous(JToken channel) =>
-                        channel.Value<string>("MeasurementCharacteristic") == "Instantaneous";
-
-                    bool IsSeriesTypeValues(JToken series) =>
-                        series.Value<string>("SeriesType") == "Values" ||
-                        series.Value<string>("SeriesType") == "Instantaneous";
-
-                    bool IsEventChannel(JToken channel) =>
-                        IsInstantaneous(channel) &&
-                        channel["Series"] is JArray series &&
-                        series.Count == 1 &&
-                        series.Any(IsSeriesTypeValues);
-
-                    bool IsTrendChannel(JToken channel) =>
-                        !IsEventChannel(channel);
-
-                    IEnumerable<JToken> FilterChannels()
-                    {
-                        switch (filter.ToLower())
-                        {
-                            case "event": return channelArray.Where(IsEventChannel);
-                            case "trend": return channelArray.Where(IsTrendChannel);
-                            default: return channelArray;
-                        }
-                    }
-
-                    return Ok(FilterChannels());
-                }
-            }
-            else
+            if (GetRoles != string.Empty && !User.IsInRole(GetRoles))
                 return Unauthorized();
+
+            const string ChannelQuery =
+            "SELECT " +
+            "    Channel.ID, " +
+            "    Meter.AssetKey AS Meter, " +
+            "    Asset.AssetKey AS Asset, " +
+            "    MeasurementType.Name AS MeasurementType, " +
+            "    MeasurementCharacteristic.Name AS MeasurementCharacteristic, " +
+            "    Phase.Name AS Phase, " +
+            "    Channel.Name, " +
+            "    Channel.Adder, " +
+            "    Channel.Multiplier, " +
+            "    Channel.SamplesPerHour, " +
+            "    Channel.PerUnitValue, " +
+            "    Channel.HarmonicGroup, " +
+            "    Channel.Description, " +
+            "    Channel.Enabled, " +
+            "    Channel.ConnectionPriority " +
+            "FROM " +
+            "    Channel JOIN " +
+            "    Asset ON Channel.AssetID = Asset.ID JOIN " +
+            "    Meter ON Channel.MeterID = Meter.ID JOIN " +
+            "    MeasurementType ON Channel.MeasurementTypeID = MeasurementType.ID JOIN " +
+            "    MeasurementCharacteristic ON Channel.MeasurementCharacteristicID = MeasurementCharacteristic.ID JOIN " +
+            "    Phase ON Channel.PhaseID = Phase.ID " +
+            "WHERE MeterID = {0}";
+
+            const string SeriesQuery =
+                "SELECT " +
+                "    Series.ID, " +
+                "    Series.ChannelID, " +
+                "    SeriesType.Name AS SeriesType, " +
+                "    Series.SourceIndexes " +
+                "FROM " +
+                "    Series JOIN " +
+                "    SeriesType ON Series.SeriesTypeID = SeriesType.ID JOIN " +
+                "    Channel ON Series.ChannelID = Channel.ID " +
+                "WHERE Channel.MeterID = {0}";
+
+        using (AdoDataConnection connection = new AdoDataConnection(Connection))
+        {
+            DataTable channelTable = connection.RetrieveData(ChannelQuery, meterID);
+            string channelJSON = JsonConvert.SerializeObject(channelTable);
+            JArray channelArray = JArray.Parse(channelJSON);
+
+                DataTable seriesTable = connection.RetrieveData(SeriesQuery, meterID);
+                string seriesJSON = JsonConvert.SerializeObject(seriesTable);
+                JArray seriesArray = JArray.Parse(seriesJSON);
+
+                int GetChannelID(JToken channel) => channel.Value<int>("ID");
+                int GetSeriesChannelID(JToken series) => series.Value<int>("ChannelID");
+
+                var groupings = channelArray
+                    .GroupJoin(seriesArray, GetChannelID, GetSeriesChannelID, (Channel, Series) => new { Channel, Series });
+
+                foreach (var grouping in groupings)
+                    grouping.Channel["Series"] = new JArray(grouping.Series);
+
+                bool IsInstantaneous(JToken channel) =>
+                    channel.Value<string>("MeasurementCharacteristic") == "Instantaneous";
+
+                bool IsSeriesTypeValues(JToken series) =>
+                    series.Value<string>("SeriesType") == "Values" ||
+                    series.Value<string>("SeriesType") == "Instantaneous";
+
+                bool IsEventChannel(JToken channel) =>
+                    IsInstantaneous(channel) &&
+                    channel["Series"] is JArray series &&
+                    series.Count == 1 &&
+                    series.Any(IsSeriesTypeValues);
+
+                bool IsTrendChannel(JToken channel) =>
+                    !IsEventChannel(channel);
+
+                IEnumerable<JToken> FilterChannels()
+                {
+                    switch (filter.ToLower())
+                    {
+                        case "event": return channelArray.Where(IsEventChannel);
+                        case "trend": return channelArray.Where(IsTrendChannel);
+                        default: return channelArray;
+                    }
+                }
+
+                return Ok(FilterChannels());
+            }
+        
+            
         }
 
         [HttpGet, Route("{meterID:int}/Asset/{sort=AssetKey}/{ascending:int=1}")]
         public IHttpActionResult GetMeterAssets(int meterID, string sort, int ascending)
         {
-            if (GetRoles == string.Empty || User.IsInRole(GetRoles))
-            {
-                using (AdoDataConnection connection = new AdoDataConnection(Connection))
-                {
-                    DataTable records = connection.RetrieveData($@"
-                    SELECT 
-	                    Asset.ID,
-	                    Asset.VoltageKV,
-	                    Asset.AssetKey,
-	                    Asset.Description,
-	                    Asset.AssetName,
-	                    Asset.AssetTypeID,
-	                    AssetType.Name as AssetType,
-	                    COUNT(Channel.ID) as Channels
-                    FROM
-	                    Asset JOIN
-	                    AssetType ON Asset.AssetTypeID = AssetType.ID JOIN
-	                    MeterAsset ON Asset.ID = MeterAsset.AssetID LEFT JOIN
-	                    Channel ON Asset.ID = Channel.AssetID AND Channel.MeterID = MeterAsset.MeterID
-                    WHERE
-	                    MeterAsset.MeterID = {{0}}
-                    GROUP BY
-	                    Asset.ID,
-	                    Asset.VoltageKV,
-	                    Asset.AssetKey,
-	                    Asset.Description,
-	                    Asset.AssetName,
-	                    Asset.AssetTypeID,
-	                    AssetType.Name   
-                    ORDER BY {sort} {(ascending == 0 ? "DESC" : "")}
-                ", meterID);
-                    return Ok(records);
-                }
-            }
-            else
+            if (GetRoles != string.Empty && !User.IsInRole(GetRoles))
                 return Unauthorized();
+            
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                DataTable records = connection.RetrieveData($@"
+                SELECT 
+                    Asset.ID,
+                    Asset.VoltageKV,
+                    Asset.AssetKey,
+                    Asset.Description,
+                    Asset.AssetName,
+                    Asset.AssetTypeID,
+                    AssetType.Name as AssetType,
+                    COUNT(Channel.ID) as Channels
+                FROM
+                    Asset JOIN
+                    AssetType ON Asset.AssetTypeID = AssetType.ID JOIN
+                    MeterAsset ON Asset.ID = MeterAsset.AssetID LEFT JOIN
+                    Channel ON Asset.ID = Channel.AssetID AND Channel.MeterID = MeterAsset.MeterID
+                WHERE
+                    MeterAsset.MeterID = {{0}}
+                GROUP BY
+                    Asset.ID,
+                    Asset.VoltageKV,
+                    Asset.AssetKey,
+                    Asset.Description,
+                    Asset.AssetName,
+                    Asset.AssetTypeID,
+                    AssetType.Name   
+                ORDER BY {sort} {(ascending == 0 ? "DESC" : "")}
+            ", meterID);
+                return Ok(records);
+            }
+            
         }
 
         [HttpDelete, Route("{meterID:int}/Asset/{assetID:int}/{locationID:int}")]
         public IHttpActionResult DeleteMeterAsset(int meterID, int assetID, int locationID)
         {
-            if (DeleteRoles == string.Empty || User.IsInRole(DeleteRoles))
-            {
-                using (AdoDataConnection connection = new AdoDataConnection(Connection))
-                {
-                    try
-                    {
-                        new TableOperations<MeterAsset>(connection).DeleteRecordWhere("MeterID = {0} AND AssetID = {1}", meterID, assetID);
-                        new TableOperations<AssetLocation>(connection).DeleteRecordWhere("LocationID = {0} AND AssetID = {1}", locationID, assetID);
-
-                        return Ok("Completed without errors.");
-                    }
-                    catch (Exception ex)
-                    {
-                        return InternalServerError(ex);
-                    }
-                }
-            }
-            else
+            if (DeleteRoles != string.Empty && !User.IsInRole(DeleteRoles))
                 return Unauthorized();
             
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                try
+                {
+                    new TableOperations<MeterAsset>(connection).DeleteRecordWhere("MeterID = {0} AND AssetID = {1}", meterID, assetID);
+                    new TableOperations<AssetLocation>(connection).DeleteRecordWhere("LocationID = {0} AND AssetID = {1}", locationID, assetID);
+
+                    return Ok("Completed without errors.");
+                }
+                catch (Exception ex)
+                {
+                    return InternalServerError(ex);
+                }
+            }    
         }
 
         [HttpPost, Route("{meterID:int}/Asset/{assetID:int}/{locationID:int}")]
         public IHttpActionResult AddMeterAsset(int meterID, int assetID, int locationID)
         {
-            if (PostRoles == string.Empty || User.IsInRole(PostRoles))
-            {
-                using (AdoDataConnection connection = new AdoDataConnection(Connection))
-                {
-                    try
-                    {
-                        MeterAsset meterAsset = new TableOperations<MeterAsset>(connection).QueryRecordWhere("MeterID = {0} AND AssetID = {1}", meterID, assetID);
-                        if (meterAsset is null) 
-                            new TableOperations<MeterAsset>(connection).AddNewRecord(new MeterAsset() { MeterID = meterID, AssetID = assetID});
 
-                        AssetLocation assetLoc = new TableOperations<AssetLocation>(connection).QueryRecordWhere("LocationID = {0} AND AssetID = {1}", locationID, assetID);
-                        if (assetLoc is null)
-                            new TableOperations<AssetLocation>(connection).AddNewRecord(new AssetLocation() { LocationID = locationID, AssetID = assetID });
-                     
-                        return Ok(1);
-                    }
-                    catch (Exception ex)
-                    {
-                        return InternalServerError(ex);
-                    }
-                }
-            }
-            else
+            if (PostRoles != string.Empty && !User.IsInRole(PostRoles))
                 return Unauthorized();
+            
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                try
+                {
+                    MeterAsset meterAsset = new TableOperations<MeterAsset>(connection).QueryRecordWhere("MeterID = {0} AND AssetID = {1}", meterID, assetID);
+                    if (meterAsset is null) 
+                        new TableOperations<MeterAsset>(connection).AddNewRecord(new MeterAsset() { MeterID = meterID, AssetID = assetID});
+
+                    AssetLocation assetLoc = new TableOperations<AssetLocation>(connection).QueryRecordWhere("LocationID = {0} AND AssetID = {1}", locationID, assetID);
+                    if (assetLoc is null)
+                        new TableOperations<AssetLocation>(connection).AddNewRecord(new AssetLocation() { LocationID = locationID, AssetID = assetID });
+                    
+                    return Ok(1);
+                }
+                catch (Exception ex)
+                {
+                    return InternalServerError(ex);
+                }
+            }               
 
         }
 
@@ -521,28 +513,27 @@ namespace SystemCenter.Controllers.OpenXDA
         {
             try
             {
-                if (GetRoles == string.Empty || User.IsInRole(GetRoles))
-                {
-                    string afTbl = TableOperations<AdditionalField>.GetTableName();
-                    string afvTbl = TableOperations<AdditionalFieldValue>.GetTableName();
-
-                    using (AdoDataConnection connection = new AdoDataConnection(Connection))
-                    {
-                        string query = $@"SELECT MIN(UpdatedOn) AS lastUpdate, {afTbl}.ExternalDB AS name  
-                                                    FROM 
-                                                    {afTbl} LEFT JOIN {afvTbl} ON {afTbl}.ID = {afvTbl}.AdditionalFieldID
-                                                    WHERE 
-                                                        {afTbl}.ParentTable = 'Meter'
-                                                        AND {afTbl}.ExternalDB IS NOT NULL AND {afTbl}.ExternalDB <> ''
-                                                    GROUP BY {afTbl}.ExternalDB";
-
-                        DataTable table = connection.RetrieveData(query);
-
-                        return Ok(table);
-                    }
-                }
-                else
+                if (GetRoles != string.Empty && !User.IsInRole(GetRoles))
                     return Unauthorized();
+
+                string afTbl = TableOperations<AdditionalField>.GetTableName();
+                string afvTbl = TableOperations<AdditionalFieldValue>.GetTableName();
+
+                using (AdoDataConnection connection = new AdoDataConnection(Connection))
+                {
+                    string query = $@"SELECT MIN(UpdatedOn) AS lastUpdate, {afTbl}.ExternalDB AS name  
+                                                FROM 
+                                                {afTbl} LEFT JOIN {afvTbl} ON {afTbl}.ID = {afvTbl}.AdditionalFieldID
+                                                WHERE 
+                                                    {afTbl}.ParentTable = 'Meter'
+                                                    AND {afTbl}.ExternalDB IS NOT NULL AND {afTbl}.ExternalDB <> ''
+                                                GROUP BY {afTbl}.ExternalDB";
+
+                    DataTable table = connection.RetrieveData(query);
+
+                    return Ok(table);
+                }
+               
             }
             catch (Exception ex)
             {
@@ -589,51 +580,48 @@ namespace SystemCenter.Controllers.OpenXDA
         {
             try
             {
-                if (PostAuthCheck())
-                {
-                    using (AdoDataConnection connection = new AdoDataConnection(Connection))
-                    {
-
-                        EventChannel newRecord = record.ToObject<EventChannel>();
-
-                        IEnumerable<MeasurementCharacteristic> measurementCharacteristics = new TableOperations<MeasurementCharacteristic>(connection).QueryRecordsWhere("Name = 'Instantaneous'");
-                        IEnumerable<SeriesType> seriesTypes = new TableOperations<SeriesType>(connection).QueryRecordsWhere("Name = 'Values'");
-
-                        ChannelBase channel = new ChannelBase() {
-                            MeterID = newRecord.MeterID,
-                            AssetID = newRecord.AssetID,
-                            MeasurementTypeID = newRecord.MeasurementTypeID,
-                            Adder = newRecord.Adder,
-                            MeasurementCharacteristicID = measurementCharacteristics.First()?.ID ?? 0,
-                            ConnectionPriority = newRecord.ConnectionPriority,
-                            PhaseID = newRecord.PhaseID,
-                            Name = newRecord.Name,
-                            Multiplier = newRecord.Multiplier,
-                            SamplesPerHour = newRecord.SamplesPerHour,
-                            PerUnitValue = newRecord.PerUnitValue,
-                            HarmonicGroup = newRecord.HarmonicGroup,
-                            Description = newRecord.Description,
-                            Enabled = newRecord.Enabled,
-                        };
-
-
-                        int result = new TableOperations<ChannelBase>(connection).AddNewRecord(channel);
-                        int channelID = connection.ExecuteScalar<int>("SELECT @@IDENTITY");
-
-                        Series series = new Series() { 
-                            SeriesTypeID = seriesTypes.First()?.ID ?? 0,
-                            SourceIndexes = newRecord.SourceIndices,
-                            ChannelID = channelID
-                        };
-
-                        result = new TableOperations<Series>(connection).AddNewRecord(series);
-
-                        return Ok(result);
-                    }
-                }
-                else
-                {
+                if (!PostAuthCheck())
                     return Unauthorized();
+
+                
+                using (AdoDataConnection connection = new AdoDataConnection(Connection))
+                {
+
+                    EventChannel newRecord = record.ToObject<EventChannel>();
+
+                    IEnumerable<MeasurementCharacteristic> measurementCharacteristics = new TableOperations<MeasurementCharacteristic>(connection).QueryRecordsWhere("Name = 'Instantaneous'");
+                    IEnumerable<SeriesType> seriesTypes = new TableOperations<SeriesType>(connection).QueryRecordsWhere("Name = 'Values'");
+
+                    ChannelBase channel = new ChannelBase() {
+                        MeterID = newRecord.MeterID,
+                        AssetID = newRecord.AssetID,
+                        MeasurementTypeID = newRecord.MeasurementTypeID,
+                        Adder = newRecord.Adder,
+                        MeasurementCharacteristicID = measurementCharacteristics.First()?.ID ?? 0,
+                        ConnectionPriority = newRecord.ConnectionPriority,
+                        PhaseID = newRecord.PhaseID,
+                        Name = newRecord.Name,
+                        Multiplier = newRecord.Multiplier,
+                        SamplesPerHour = newRecord.SamplesPerHour,
+                        PerUnitValue = newRecord.PerUnitValue,
+                        HarmonicGroup = newRecord.HarmonicGroup,
+                        Description = newRecord.Description,
+                        Enabled = newRecord.Enabled,
+                    };
+
+
+                    int result = new TableOperations<ChannelBase>(connection).AddNewRecord(channel);
+                    int channelID = connection.ExecuteScalar<int>("SELECT @@IDENTITY");
+
+                    Series series = new Series() { 
+                        SeriesTypeID = seriesTypes.First()?.ID ?? 0,
+                        SourceIndexes = newRecord.SourceIndices,
+                        ChannelID = channelID
+                    };
+
+                    result = new TableOperations<Series>(connection).AddNewRecord(series);
+
+                    return Ok(result);
                 }
 
             }
@@ -645,20 +633,14 @@ namespace SystemCenter.Controllers.OpenXDA
 
         public override IHttpActionResult Delete(EventChannel record)
         {
-            if (DeleteAuthCheck())
-            {
-
-                using (AdoDataConnection connection = new AdoDataConnection(Connection))
-                {
-                    int result = connection.ExecuteNonQuery($"EXEC UniversalCascadeDelete Channel, 'ID = ''{record.ID}'''");
-                    return Ok(result);
-                }
-            }
-            else
-            {
+            if (!DeleteAuthCheck())
                 return Unauthorized();
-            }
 
+            using (AdoDataConnection connection = new AdoDataConnection(Connection))
+            {
+                int result = connection.ExecuteNonQuery($"EXEC UniversalCascadeDelete Channel, 'ID = ''{record.ID}'''");
+                return Ok(result);
+            }
         }
 
         public override IHttpActionResult Patch([FromBody] EventChannel record)
@@ -666,8 +648,10 @@ namespace SystemCenter.Controllers.OpenXDA
 
             try
             {
-                if (PatchAuthCheck())
-                {
+                if (!PatchAuthCheck())
+                    return Unauthorized();
+
+                
 
                     using (AdoDataConnection connection = new AdoDataConnection(Connection))
                     {
@@ -701,13 +685,6 @@ namespace SystemCenter.Controllers.OpenXDA
 
                         return Ok(result);
                     }
-                }
-                else
-                {
-                    return Unauthorized();
-                }
-
-
             }
             catch (Exception ex)
             {

--- a/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
@@ -543,10 +543,11 @@ namespace SystemCenter.Controllers
 
                     int harmonic = 0;
                     int harmonicGroup = observations
-                    .SelectMany(observation => observation.ChannelInstances)
-                    .Where(channelInstance => ReferenceEquals(parser.DataSourceRecords.First().ChannelDefinitions[(int)channelInstance.ChannelDefinitionIndex], cd))
-                    .Select(channelInstance => channelInstance.ChannelGroupID)
-                    .FirstOrDefault(channelGroupIndex => channelGroupIndex != 0);
+                        .Where(observation => ReferenceEquals(observation.DataSource, cd.DataSource))
+                        .SelectMany(observation => observation.ChannelInstances)
+                        .Where(channelInstance => ReferenceEquals(channelInstance.ChannelDefinition, cd))
+                        .Select(channelInstance => channelInstance.ChannelGroupID)
+                        .FirstOrDefault(channelGroupIndex => channelGroupIndex != 0);
 
                     var series = cd.SeriesDefinitions.Where(s => s.ValueTypeID == SeriesValueType.Val || s.ValueTypeID == SeriesValueType.Max || s.ValueTypeID == SeriesValueType.Min || s.ValueTypeID == SeriesValueType.Avg)
                     .Select(d => new {

--- a/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
@@ -23,6 +23,7 @@
 
 using GSF.Data;
 using GSF.Data.Model;
+using GSF.PhasorProtocols;
 using GSF.PQDIF.Logical;
 using GSF.Web.Model;
 using Newtonsoft.Json.Linq;
@@ -513,6 +514,10 @@ namespace SystemCenter.Controllers
                 IEnumerable<ChannelDefinition> channelDefinitions = parser.DataSourceRecords.First().ChannelDefinitions
                     .Where(cd => cd.SeriesDefinitions.Where(ser => ser.QuantityCharacteristicID == QuantityCharacteristic.Instantaneous).Any());
 
+                List<ObservationRecord> observations = new List<ObservationRecord>();
+                while (parser.HasNextObservationRecord())
+                    observations.Add(parser.NextObservationRecord());
+
                 var channels = channelDefinitions.Select((cd,index) => {
 
                     Guid characteristic = cd.SeriesDefinitions
@@ -536,6 +541,12 @@ namespace SystemCenter.Controllers
                         return "Values";
                     };
 
+                    int harmonic = 0;
+                    int harmonicGroup = observations
+                    .SelectMany(observation => observation.ChannelInstances)
+                    .Where(channelInstance => ReferenceEquals(parser.DataSourceRecords.First().ChannelDefinitions[(int)channelInstance.ChannelDefinitionIndex], cd))
+                    .Select(channelInstance => channelInstance.ChannelGroupID)
+                    .FirstOrDefault(channelGroupIndex => channelGroupIndex != 0);
 
                     var series = cd.SeriesDefinitions.Where(s => s.ValueTypeID == SeriesValueType.Val || s.ValueTypeID == SeriesValueType.Max || s.ValueTypeID == SeriesValueType.Min || s.ValueTypeID == SeriesValueType.Avg)
                     .Select(d => new {
@@ -544,7 +555,7 @@ namespace SystemCenter.Controllers
                         SeriesType = SeriesType(d.ValueTypeID),
                         SourceIndexes = ""
                     });
-                      
+                    
                     return new
                     {
                         ID = index + 1,
@@ -557,7 +568,7 @@ namespace SystemCenter.Controllers
                         Name = cd.ChannelName,
                         SamplesPerHour = 0,
                         PerUnitValue = 1,
-                        HarmonicGroup = 0,
+                        HarmonicGroup = harmonic,
                         Description = (cd.DataSource.DataSourceName) + " - " + cd.ChannelName,
                         Enabled = true,
                         Adder = 0,

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
@@ -84,9 +84,9 @@ export namespace AssetAttributes {
                 }
                 else {
                     let oldKey = (allAssets.find(aa => aa.ID === props.Asset.ID)  != undefined? allAssets.find(aa => aa.ID === props.Asset.ID).AssetKey.toLowerCase() : '');
-                    if (props.AllAssets != undefined && props.AllAssets.find(aa => aa.ID === props.Asset.ID) == undefined)
+                    if (props.AllAssets != undefined && props.AllAssets.find(aa => aa.ID === props.Asset.ID) != undefined)
                         oldKey = props.AllAssets.find(aa => aa.ID === props.Asset.ID).AssetKey.toLowerCase();
-                    if (oldKey == props.Asset.AssetKey)
+                    if (oldKey == props.Asset.AssetKey.toLowerCase())
                         return true;
                     else {
                         const keys = _.uniq(currentKeys.concat(...(props.AllAssets != undefined ? props.AllAssets.map(a => a.AssetKey.toLocaleLowerCase()) : [])))

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
@@ -25,13 +25,15 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Application, OpenXDA } from '@gpa-gemstone/application-typings'
 import { Input, Select, TextArea } from '@gpa-gemstone/react-forms';
+import { useAppDispatch, useAppSelector } from '../hooks';
+import { FetchAsset, SelectAssetKeysLowerCase, SelectAssets, SelectAssetStatus } from '../Store/AssetSlice';
 
 interface AssetAttributesProps {
     Asset: OpenXDA.Types.Asset,
     NewEdit: Application.Types.NewEdit,
     UpdateState: (Asset: OpenXDA.Types.Asset) => void,
     AssetTypes: Array<OpenXDA.Types.AssetType>,
-    AllAssets: Array<OpenXDA.Types.Asset>,
+    AllAssets?: Array<OpenXDA.Types.Asset>,
     GetDifferentAsset: (assetID: number) => void,
     HideSelectAsset: boolean,
     HideAssetType: boolean,
@@ -41,6 +43,15 @@ interface AssetAttributesProps {
 export namespace AssetAttributes {
 
     export function AssetAttributeFields(props: AssetAttributesProps): JSX.Element {
+        const dispatch = useAppDispatch();
+        const currentKeys = useAppSelector(SelectAssetKeysLowerCase);
+        const allAssets = useAppSelector(SelectAssets);
+        const assetStatus = useAppSelector(SelectAssetStatus);
+
+        React.useEffect(() => {
+            if (assetStatus == 'unintiated' || assetStatus == 'changed')
+                dispatch(FetchAsset());
+        }, [assetStatus]);
 
         function changeAssetType(type: OpenXDA.Types.AssetTypeName): void {
             let asset = {
@@ -64,18 +75,23 @@ export namespace AssetAttributes {
                 if (props.Asset.AssetKey == null || props.Asset.AssetKey.length == 0) return false;
                 else if (props.NewEdit == 'New') {
                     if (props.Asset.ID == 0) {
-                        return props.AllAssets.map(asset => asset.AssetKey.toLowerCase()).indexOf(props.Asset.AssetKey.toLowerCase()) < 0;
+                        const keys = _.uniq(currentKeys.concat(...(props.AllAssets != undefined ? props.AllAssets.map(a => a.AssetKey.toLocaleLowerCase()) : [])))
+                        return keys.indexOf(props.Asset.AssetKey.toLowerCase()) < 0;
                     }
                     else {
                         return true;
                     }
                 }
                 else {
-                    let oldKey = props.AllAssets.find(aa => aa.ID === props.Asset.ID) == undefined ? '' : props.AllAssets.find(aa => aa.ID === props.Asset.ID).AssetKey;
+                    let oldKey = (allAssets.find(aa => aa.ID === props.Asset.ID)  != undefined? allAssets.find(aa => aa.ID === props.Asset.ID).AssetKey.toLowerCase() : '');
+                    if (props.AllAssets != undefined && props.AllAssets.find(aa => aa.ID === props.Asset.ID) == undefined)
+                        oldKey = props.AllAssets.find(aa => aa.ID === props.Asset.ID).AssetKey.toLowerCase();
                     if (oldKey == props.Asset.AssetKey)
                         return true;
-                    else
-                        return props.AllAssets.map(asset => asset.AssetKey.toLowerCase()).indexOf(props.Asset.AssetKey.toLowerCase()) < 0;
+                    else {
+                        const keys = _.uniq(currentKeys.concat(...(props.AllAssets != undefined ? props.AllAssets.map(a => a.AssetKey.toLocaleLowerCase()) : [])))
+                        return keys.indexOf(props.Asset.AssetKey.toLowerCase()) < 0;
+                    }
                 }
             }
             else if (field == 'AssetName')

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
@@ -32,12 +32,13 @@ import LineAttributes from '../AssetAttribute/Line';
 import TransformerAttributes from '../AssetAttribute/Transformer';
 import { AssetAttributes } from '../AssetAttribute/Asset';
 import { getAssetTypes, getAssetWithAdditionalFields } from '../../../TS/Services/Asset';
-import { SearchedAssets, SearchStatus, DBSearchAsset, DBActionAsset } from '../Store/AssetSlice'
+import { SearchedAssets, SearchStatus, DBSearchAsset, DBActionAsset, DBMeterAction } from '../Store/AssetSlice'
 import Table from '@gpa-gemstone/react-table';
 import { Pencil, TrashCan } from '@gpa-gemstone/gpa-symbols';
 import { Warning, Modal, LoadingScreen, Search } from '@gpa-gemstone/react-interactive';
 import DERAttributes from '../AssetAttribute/DER';
 import { useAppDispatch, useAppSelector } from '../hooks';
+import AssetSelect from '../Asset/AssetSelect';
 
 declare var homePath: string;
 
@@ -52,6 +53,7 @@ const MeterAssetWindow = (props: IProps) => {
     const [showDeleteWarning, setShowDeleteWarning] = React.useState<boolean>(false);
 
     const [showLoading, setShowLoading] = React.useState<boolean>(false);
+    const [showSelect, setShowSelect] = React.useState<boolean>(false);
 
     // Asset Slice Consts
     const dispatch = useAppDispatch();
@@ -87,12 +89,12 @@ const MeterAssetWindow = (props: IProps) => {
             setShowLoading(true);
             reloadSlice();
         }
-    }, [dispatch, assetStatus]);
+    }, [assetStatus]);
 
     React.useEffect(() => {
         setShowLoading(true);
         reloadSlice();
-    }, [ascending, sortKey, filter, dispatch]);
+    }, [ascending, sortKey, filter]);
 
     function setActiveAsset(assetID: number, assetType: OpenXDA.Types.AssetTypeName) {
         if (assetID == 0) {
@@ -114,6 +116,7 @@ const MeterAssetWindow = (props: IProps) => {
         return null;
 
     return (
+        <>
         <div className="card" style={{ marginBottom: 10 }}>
             <div className="card-header">
                 <div className="row">
@@ -173,7 +176,7 @@ const MeterAssetWindow = (props: IProps) => {
                                 selected={(item) => false}
                             />
 
-                            <Warning Show={showDeleteWarning} CallBack={(confirmed) => { if (confirmed) dispatch(DBActionAsset({ verb: 'DELETE', record: activeAsset, meterID: props.Meter.ID, locationID: props.Meter.LocationID })); setShowDeleteWarning(false); }} Title={'Remove this Asset'} Message={'This will permanently remove this Asset from the Meter.'} />
+                                <Warning Show={showDeleteWarning} CallBack={(confirmed) => { if (confirmed) dispatch(DBMeterAction({ verb: 'DELETE', assetID: activeAsset.ID, meterID: props.Meter.ID, locationID: props.Meter.LocationID })); setShowDeleteWarning(false); }} Title={'Remove this Asset'} Message={'This will permanently remove this Asset from the Meter.'} />
                             <LoadingScreen Show={showLoading} />
                             <Modal Show={showEditNew}
                                 Title={newEdit == 'New' ? 'Add New Asset to Meter' : 'Edit ' + activeAsset.AssetKey + ' for Meter'}
@@ -211,14 +214,30 @@ const MeterAssetWindow = (props: IProps) => {
                 </div>
             </div>
             <div className="card-footer">
-                <div className="btn-group mr-2">
+                    <div className="btn-group mr-2">
+                        <button className="btn btn-primary pull-left" style={{ marginRight: 5 }} onClick={() => {
+                        setShowSelect(true);
+                    }}>Add Existing Asset</button>
                     <button className="btn btn-primary pull-right" onClick={() => {
                         setActiveAsset(0, 'Line');
                         setShoweditNew(true);
-                    }}>Add Asset</button>
+                    }}>Add New Asset</button>
                 </div>
             </div>
-        </div>
+            </div>
+            <AssetSelect
+                SelectedAssets={[]}
+                ShowModal={showSelect}
+                SessionStorageID={'MeterAsset'}
+                Type={'single'}
+                Title={`Add Asset to ${props.Meter.Name}`}
+                OnCloseFunction={(selected, confirm) => {
+                    setShowSelect(false);
+                    if (confirm) 
+                      dispatch(DBMeterAction({ verb: 'POST', assetID: selected[0].ID, meterID: props.Meter.ID, locationID: props.Meter.LocationID }));
+                }}
+            />
+            </>
     );
 
 

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
@@ -135,7 +135,6 @@ const MeterAssetWindow = (props: IProps) => {
                                     { key: 'AssetName', field: 'AssetName', label: 'Name', headerStyle: { width: 'calc(30%-16px)' }, rowStyle: { width: 'calc(30%-16px)' } },
                                     { key: 'AssetType', field: 'AssetType', label: 'Type', headerStyle: { width: 'calc(10%-16px)' }, rowStyle: { width: 'calc(10%-16px)' } },
                                     { key: 'VoltageKV', field: 'VoltageKV', label: 'Base kV', headerStyle: { width: 'calc(10%-16x)' }, rowStyle: { width: 'calc(10%-16px)' } },
-                                    { key: 'Channels', field: 'Channels', label: 'Channels', headerStyle: { width: 'calc(10%-16px)' }, rowStyle: { width: 'calc(10%-16px)' } },
                                     
                                     {
                                         key: 'EditDelete', label: '', headerStyle: { width: 80, paddingLeft: 0, paddingRight: 5 }, rowStyle: { width: 80, paddingLeft: 0, paddingRight: 5 },

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/Page3.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/Page3.tsx
@@ -280,18 +280,22 @@ export default function Page3(props: { MeterKey: string, Channels: Array<OpenXDA
                         key: 'Name', label: 'Name', headerStyle: { width: '20%' }, rowStyle: { width: '20%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Name'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
                     },
                     {
-                        key: 'Description', label: 'Desc', headerStyle: { width: '33%' }, rowStyle: { width: '33%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Description'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
+                        key: 'Description', label: 'Desc', headerStyle: { width: '26%' }, rowStyle: { width: '26%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Description'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
                     },
                     {
-                        key: 'MeasurementType', label: 'Type', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementType'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementTypes.map((t) => ({ Value: t, Label: t }))} />
+                        key: 'MeasurementType', label: 'Type', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementType'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementTypes.map((t) => ({ Value: t, Label: t }))} />
                     },
                     {
-                        key: 'Phase', label: 'Phase', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'Phase'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.Phases.map((t) => ({ Value: t, Label: t }))} />
+                        key: 'MeasurementCharacteristic', label: 'Char.', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementCharacteristic'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementCharacteristics.map((t) => ({ Value: t, Label: t }))} />
                     },
+                    {
+                        key: 'Phase', label: 'Phase', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'Phase'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.Phases.map((t) => ({ Value: t, Label: t }))} />
+                    },
+                    { key: 'HarmonicGroup', label: 'Harm', headerStyle: { width: '5%' }, rowStyle: { width: '5%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'HarmonicGroup'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
                     { key: 'Adder', label: 'Adder', headerStyle: { width: '5%' }, rowStyle: { width: '5%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Adder'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
                     { key: 'Multiplier', label: 'Multiplier', headerStyle: { width: '7%' }, rowStyle: { width: '7%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Multiplier'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
-                    { key: 'Trend', label: 'Trend', headerStyle: { width: '10%' }, rowStyle: { width: '5%', paddingTop: 36, paddingBottom: 36 }, content: (item) => item.Series.filter(s => s.SeriesType != 'Values').length > 0 ? HeavyCheckMark : CrossMark },
-                    { key: 'DeleteButton', label: '', headerStyle: { width: '0%' }, rowStyle: { width: '5%', paddingTop: 36, paddingBottom: 36 }, content: (item, field, key, style, index) => <button className="btn btn-sm" onClick={(e) => deleteChannel(index)}><span><i className="fa fa-times"></i></span></button> },
+                    { key: 'Trend', label: 'Trend', headerStyle: { width: '8%' }, rowStyle: { width: '4%', paddingTop: 36, paddingBottom: 36 }, content: (item) => item.Series.filter(s => s.SeriesType != 'Values').length > 0 ? HeavyCheckMark : CrossMark },
+                    { key: 'DeleteButton', label: '', headerStyle: { width: '0%' }, rowStyle: { width: '4%', paddingTop: 36, paddingBottom: 36 }, content: (item, field, key, style, index) => <button className="btn btn-sm" onClick={(e) => deleteChannel(index)}><span><i className="fa fa-times"></i></span></button> },
                 ]}
                     tableClass="table table-hover"
                     data={props.Channels}


### PR DESCRIPTION
Fixed the following Bugs per TVAs request:

New Meter Wizard is missing fields for Characteristic and Harmonic 
Event Channels – Channel field is blank for all channels but there is a warning stating that “SourceIndices is a required field”.
Trend Channels tab displays Harmonic field but all Harmonics are set to 0. Added logic to populate these in New Meter Wizard
Transmission Assets – Channels tab does not display any channels so I cannot verify what channels are mapped
