### PR TITLE
Fixed ErrorLog.txt and StatusLog.txt file names

### DIFF
--- a/Source/Applications/SystemCenter/ServiceHost.Designer.cs
+++ b/Source/Applications/SystemCenter/ServiceHost.Designer.cs
@@ -150,6 +150,8 @@ namespace SystemCenter
             this.m_serviceHelper = new GSF.ServiceProcess.ServiceHelper(this.components);
             this.m_remotingServer = new GSF.Communication.TcpServer(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ConnectionErrorLogger)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ConnectionErrorLogger.ErrorLog)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ErrorLogger)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ErrorLogger.ErrorLog)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ProcessScheduler)).BeginInit();
@@ -164,7 +166,10 @@ namespace SystemCenter
             // 
             // 
             // 
-            this.m_serviceHelper.ErrorLogger.ErrorLog.FileName = "openXDA.ErrorLog.txt";
+            // 
+            // 
+            // 
+            this.m_serviceHelper.ErrorLogger.ErrorLog.FileName = "SystemCenter.ErrorLog.txt";
             this.m_serviceHelper.ErrorLogger.ErrorLog.PersistSettings = true;
             this.m_serviceHelper.ErrorLogger.ErrorLog.SettingsCategory = "ErrorLog";
             this.m_serviceHelper.ErrorLogger.PersistSettings = true;
@@ -179,7 +184,7 @@ namespace SystemCenter
             // 
             // 
             // 
-            this.m_serviceHelper.StatusLog.FileName = "openXDA.StatusLog.txt";
+            this.m_serviceHelper.StatusLog.FileName = "SystemCenter.StatusLog.txt";
             this.m_serviceHelper.StatusLog.PersistSettings = true;
             this.m_serviceHelper.StatusLog.SettingsCategory = "StatusLog";
             // 
@@ -194,14 +199,14 @@ namespace SystemCenter
             // ServiceHost
             // 
             this.ServiceName = "openXDA";
+            ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ConnectionErrorLogger.ErrorLog)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ConnectionErrorLogger)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ErrorLogger.ErrorLog)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ErrorLogger)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.ProcessScheduler)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper.StatusLog)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_serviceHelper)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.m_remotingServer)).EndInit();
-
-
 
         }
 

--- a/Source/Applications/SystemCenter/ServiceHost.resx
+++ b/Source/Applications/SystemCenter/ServiceHost.resx
@@ -112,18 +112,18 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="m_serviceHelper.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 54</value>
+  <metadata name="m_serviceHelper.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 56</value>
   </metadata>
-  <metadata name="$this.TrayLargeIcon" type="System.Boolean, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="$this.TrayLargeIcon" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>False</value>
   </metadata>
-  <metadata name="m_remotingServer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="m_remotingServer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>16, 92</value>
   </metadata>
 </root>


### PR DESCRIPTION
Renamed `openXDA.ErrorLog.txt` and `openXDA.StatusLog.txt` to `SystemCenter.ErrorLog.txt` and `SystemCenter.StatusLog.txt` respectively. This has just bothered me for a long time.