### PR TITLE
Do not attempt to log stack frames that do not exist

### DIFF
--- a/Source/Applications/SystemCenter/ServiceHost.cs
+++ b/Source/Applications/SystemCenter/ServiceHost.cs
@@ -1010,7 +1010,11 @@ namespace SystemCenter
                 if (logMessage.Level == MessageLevel.NA)
                     return;
 
-                LogStackFrame firstStackFrame = logMessage.CurrentStackTrace.Frames[0];
+                LogStackFrame firstStackFrame = logMessage.CurrentStackTrace.Frames.FirstOrDefault();
+
+                if (firstStackFrame is null)
+                    return;
+
                 string className = firstStackFrame.ClassName;
                 string methodName = firstStackFrame.MethodName;
                 string fileName = firstStackFrame.FileName;


### PR DESCRIPTION
Exceptions here don't seem to cause problems for release builds, but it's annoying with a debugger attached. Better if we handle it properly.