### PR TITLE
Fixed MagDur Curve edit

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/MagDurCurves/CurveForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/MagDurCurves/CurveForm.tsx
@@ -209,7 +209,7 @@ export default function CurveForm(props: IProps) {
                     />
                     <form>
                         <button className="btn btn-primary"
-                            onClick={(event) => { event.preventDefault(); setCurve((d) => [...d, d[d.length-1]]); }}
+                            onClick={(event) => { event.preventDefault(); setCurve((d) => [...d, [d[d.length-1][0], d[d.length-1][1]]]); }}
                         >Add Point</button>
                     </form>
                 </div>


### PR DESCRIPTION
This resolves the issue where the `Add` button adds a new point. It copies the previous point to make sure everything is still valid, but used to copy the reference instead of creating a new point at the same location.