### PR TITLE
Ticket_1390, Ticket_1322

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ByApplicationCategory.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ByApplicationCategory.tsx
@@ -60,8 +60,7 @@ const ByApplicationCategory: Application.Types.iByComponent = (props) => {
 
     const searchFields: Search.IField<SystemCenter.Types.Setting>[] = [
         { key: 'Name', label: 'Name', type: 'string', isPivotField: false },
-        { key: 'SortOrder', label: 'SortOrder', type: 'integer', isPivotField: false },
-        { key: 'Value', label: 'Value', type: 'string', isPivotField: false }
+        { key: 'SortOrder', label: 'Sort Order', type: 'integer', isPivotField: false },
     ]
 
     React.useEffect(() => {
@@ -85,7 +84,7 @@ const ByApplicationCategory: Application.Types.iByComponent = (props) => {
         if (editNewApplicationCategory.Name != null && editNewApplicationCategory.Name.length > 0 && allApplicationCategories.findIndex(s => s.Name.toLowerCase() === editNewApplicationCategory.Name.toLowerCase() && s.ID !== editNewApplicationCategory.ID) > -1)
             e.push('A Application Category with this Name already exists.')
         if (editNewApplicationCategory.SortOrder == null || editNewApplicationCategory.SortOrder === 0)
-            e.push('A SortOrder value is required')
+            e.push('A Sort Order value is required')
         setErrors(e)
     }, [editNewApplicationCategory])
 
@@ -172,7 +171,7 @@ const ByApplicationCategory: Application.Types.iByComponent = (props) => {
                             Valid={Valid}
                             Setter={(record) => { setEditNewApplicationCategory(record);}}
                         />
-                        <Input<ApplicationCategory> Record={editNewApplicationCategory} Field={'SortOrder'} Label='SortOrder' Feedback={'A SortOrder value is required.'}
+                        <Input<ApplicationCategory> Record={editNewApplicationCategory} Field={'SortOrder'} Label='Sort Order' Feedback={'A Sort Order value is required.'}
                             Type={'number'}
                             Valid={Valid}
                             Setter={(record) => { setEditNewApplicationCategory(record);}}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationManagment/ApplicationNode.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationManagment/ApplicationNode.tsx
@@ -74,8 +74,8 @@ const ByApplicationNode: Application.Types.iByComponent = (props) => {
     }, [editnewNode])
 
     const searchFields: Search.IField<SystemCenter.Types.Setting>[] = [
-        { key: 'Name', label: 'Name', type: 'string', isPivotField: false },
-        { key: 'ID', label: 'NodeID', type: 'string', isPivotField: false }
+        { key: 'Name', label: 'Application Name', type: 'string', isPivotField: false },
+        { key: 'ID', label: 'Node ID', type: 'string', isPivotField: false }
     ]
 
     if (status === 'error')
@@ -88,7 +88,7 @@ const ByApplicationNode: Application.Types.iByComponent = (props) => {
             <LoadingScreen Show={status === 'loading'} />
             <div style={{ width: '100%', height: '100%' }}>
                 <SearchBar<SystemCenter.Types.Setting> CollumnList={searchFields} SetFilter={(flds) => dispatch(ApplicationNodeSlice.DBSearch({ filter: flds, sortField, ascending }))}
-                    Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
+                    Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Application Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
                     ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Applications'}
                     GetEnum={() => {
                         return () => { }

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/AssetAssetGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/AssetAssetGroup.tsx
@@ -172,7 +172,7 @@ function AssetAssetGroupWindow(props: { AssetGroupID: number}) {
                     if (!conf) return
                     saveItems(selected.filter(items => assetList.findIndex(g => g.ID == items.ID) < 0))
                 }} />
-            <Warning Show={removeAsset > -1} Title={'Remove Asset from Group'} Message={'This will remove the transmission asset from this AssetGroup'} CallBack={(c) => { if (c) removeItem(removeAsset); setRemoveAsset(-1); }} />
+            <Warning Show={removeAsset > -1} Title={'Remove Asset from Group'} Message={'This will remove the transmission asset from this Asset Group'} CallBack={(c) => { if (c) removeItem(removeAsset); setRemoveAsset(-1); }} />
             </>
     )
 }

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/AssetGroupAssetGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/AssetGroupAssetGroup.tsx
@@ -205,7 +205,7 @@ function AssetGroupAssetGroupWindow(props: { AssetGroupID: number}) {
                     Title={"Add Asset Groups to Asset Group"}
                     GetEnum={getEnum}
                     GetAddlFields={() => () => { }} />
-                <Warning Show={removeGroup > -1} Title={'Remove Asset Group from Group'} Message={'This will remove the Asset Group from this AssetGroup'} CallBack={(c) => { if (c) removeItem(removeGroup); setRemoveGroup(-1); }} />
+                <Warning Show={removeGroup > -1} Title={'Remove Asset Group from Group'} Message={'This will remove the Asset Group from this Asset Group'} CallBack={(c) => { if (c) removeItem(removeGroup); setRemoveGroup(-1); }} />
             </div>
             </>
     );

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/AssetGroupInfo.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/AssetGroupInfo.tsx
@@ -85,7 +85,6 @@ function AssetgroupInfoWindow(props: { AssetGroup: OpenXDA.Types.AssetGroup, Sta
                     <div className="col">
                         <Input<OpenXDA.Types.AssetGroup> Record={assetGroup} Field={'Assets'} Label={'Num. of Transmission Assets'}  Valid={() => true} Setter={setAssetGroup} Disabled={true} />
                         <Input<OpenXDA.Types.AssetGroup> Record={assetGroup} Field={'Meters'} Label={'Num. of Meters'} Valid={() => true} Setter={setAssetGroup} Disabled={true} />
-                        <Input<OpenXDA.Types.AssetGroup> Record={assetGroup} Field={'Users'} Label={'Num. of Users'} Valid={() => true} Setter={setAssetGroup} Disabled={true} />
                         <Input<OpenXDA.Types.AssetGroup> Record={assetGroup} Field={'AssetGroups'} Label={'Num. of Asset Groups'} Valid={() => true} Setter={setAssetGroup} Disabled={true} />
                     </div>
                 </div>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/MeterAssetGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetGroups/MeterAssetGroup.tsx
@@ -224,7 +224,7 @@ function MeterAssetGroupWindow(props: { AssetGroupID: number}) {
                 Title={"Add Meters to Asset Group"}
                 GetEnum={getEnum}
                 GetAddlFields={getAdditionalMeterFields} />
-            <Warning Show={removeMeter > -1} Title={'Remove Meter from Group'} Message={'This will remove the meter from this AssetGroup'} CallBack={(c) => { if (c) removeItem(removeMeter); setRemoveMeter(-1);  }} />
+            <Warning Show={removeMeter > -1} Title={'Remove Meter from Group'} Message={'This will remove the meter from this Asset Group'} CallBack={(c) => { if (c) removeItem(removeMeter); setRemoveMeter(-1);  }} />
         </>
     );
 }

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/CommonComponents/SearchFields.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/CommonComponents/SearchFields.tsx
@@ -41,7 +41,7 @@ export namespace SearchFields {
 
     export const ValueListGroup = [
         { label: 'Name', key: 'Name', type: 'string', isPivotField: false },
-        { label: 'Description/Comments', key: 'Description', type: 'string', isPivotField: false },
+        { label: 'Description', key: 'Description', type: 'string', isPivotField: false },
 
     ];
 

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ByExternalDB.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ByExternalDB.tsx
@@ -35,8 +35,8 @@ import { ExternalDBTablesSlice } from '../Store/Store';
 declare var homePath: string;
 
 const defaultSearchcols: Array<Search.IField<SystemCenter.Types.ExternalDataBaseTable>> = [
-    { label: 'TableName', key: 'TableName', type: 'string', isPivotField: false },
-    { label: 'ExternalDB', key: 'ExternalDB', type: 'string', isPivotField: false },
+    { label: 'Table Name', key: 'TableName', type: 'string', isPivotField: false },
+    { label: 'External DB', key: 'ExternalDB', type: 'string', isPivotField: false },
 ];
 
 const ByExternalDB: Application.Types.iByComponent = (props) => {
@@ -78,7 +78,7 @@ const ByExternalDB: Application.Types.iByComponent = (props) => {
         history.push({ pathname: homePath + 'index.cshtml', search: '?name=ExternalDB&ID=' + item.row.ID })
     }
 
-    const standardSearch: Search.IField<SystemCenter.Types.ExternalDataBaseTable> = { label: 'Name', key: 'TableName', type: 'string', isPivotField: false };
+    const standardSearch: Search.IField<SystemCenter.Types.ExternalDataBaseTable> = { label: 'Table Name', key: 'TableName', type: 'string', isPivotField: false };
 
     return (
         <div style={{ width: '100%', height: '100%' }}>
@@ -126,7 +126,7 @@ const ByExternalDB: Application.Types.iByComponent = (props) => {
             <div style={{ width: '100%', height: 'calc( 100% - 136px)' }}>
                 <Table
                     cols={[
-                        { key: 'TableName', field: 'TableName', label: 'Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
+                        { key: 'TableName', field: 'TableName', label: 'Table Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'ExternalDB', field: 'ExternalDB', label: 'External Database', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'Scroll', label: '', headerStyle: { width: 17, padding: 0 }, rowStyle: { width: 0, padding: 0 } }                      
                     ]}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ExternalDBForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ExternalDBForm.tsx
@@ -67,7 +67,7 @@ export default function ExternalDBForm(props: IProps) {
 
     return (
         <form>
-            <Input<SystemCenter.Types.ExternalDataBaseTable> Record={props.ExternalDB} Field={'TableName'} Label={'Name'} Feedback={"A unique Name of less than 200 characters is required."} Valid={Valid} Setter={props.Setter} />
+            <Input<SystemCenter.Types.ExternalDataBaseTable> Record={props.ExternalDB} Field={'TableName'} Label={'Table Name'} Feedback={"A unique Name of less than 200 characters is required."} Valid={Valid} Setter={props.Setter} />
             <Select<SystemCenter.Types.ExternalDataBaseTable> Record={props.ExternalDB} Field={'ExternalDB'} Label={'External Database'} Options={Options} Setter={props.Setter} />
         </form>
 

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationMeter.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationMeter.tsx
@@ -70,8 +70,8 @@ function LocationMeterWindow(props: { Location: OpenXDA.Types.Location }): JSX.E
                             { key: 'AssetKey', field: 'AssetKey', label: 'Key', headerStyle: { width: '30%' }, rowStyle: { width: '30%' } },
                             { key: 'Name', field: 'Name', label: 'Name', headerStyle: { width: '30%' }, rowStyle: { width: '30%' } },
                             //{ key: 'Type', label: 'Type', headerStyle: { width: '10%' }, rowStyle: { width: '10%' } },
-                            { key: 'Make', field: 'Make', label: 'Meters', headerStyle: { width: '10%' }, rowStyle: { width: '10%' } },
-                            { key: 'Model', field: 'Model', label: 'Assets', headerStyle: { width: 'calc(10%)' }, rowStyle: { width: '10%' } },
+                            { key: 'Make', field: 'Make', label: 'Make', headerStyle: { width: '10%' }, rowStyle: { width: '10%' } },
+                            { key: 'Model', field: 'Model', label: 'Model', headerStyle: { width: 'calc(10%)' }, rowStyle: { width: '10%' } },
                         ]}
                         tableClass="table table-hover"
                         data={meters}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ProcessedFile/ByFile.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ProcessedFile/ByFile.tsx
@@ -131,7 +131,7 @@ const ByFile: Application.Types.iByComponent = (props) => {
             <div style={{ width: '100%', height: 'calc( 100% - 136px)' }}>
                 <Table<OpenXDA.Types.DataFile>
                     cols={[
-                        { key: 'Path', field: 'FilePath', label: 'Path', headerStyle: { width: '70%' }, rowStyle: { width: '70%' }, content: (f) => f.FilePath.length > 100 ? f.FilePath.substr(f.FilePath.length - 100, 100) : f.FilePath },
+                        { key: 'Path', field: 'FilePath', label: 'File Path', headerStyle: { width: '70%' }, rowStyle: { width: '70%' }, content: (f) => f.FilePath.length > 100 ? f.FilePath.substr(f.FilePath.length - 100, 100) : f.FilePath },
                         { key: 'CreationTime', field: 'CreationTime', label: 'File Created', headerStyle: { width: '15%' }, rowStyle: { width: '15%' }, content: f => moment(f.CreationTime).format('MM/DD/YYYY HH:mm.ss.ssss') },
                         { key: 'DataStartTime', field: 'DataStartTime', label: 'Data Start', headerStyle: { width: '15%' }, rowStyle: { width: '15%' }, content: f => moment(f.DataStartTime).format('MM/DD/YYYY HH:mm.ss.ssss') },
                         { key: 'Scroll', label: '', headerStyle: { width: 17, padding: 0 }, rowStyle: { width: 0, padding: 0 } },

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteMeterForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteMeterForm.tsx
@@ -96,7 +96,7 @@ export default function RemoteMeterForm(props: IProps) {
             <form>
                 <div className="col" style={{ width: '50%', float: "left" }}>
                     <Input<OpenXDA.Types.RemoteXDAMeter> Record={formMeter} Field={'LocalMeterName'} Label={'Local Meter Name'} Valid={() => true} Setter={() => { }} Disabled={true} />
-                    <Input<OpenXDA.Types.RemoteXDAMeter> Record={formMeter} Field={'LocalAssetKey'} Label={'Local Asset Key'} Valid={() => true} Setter={() => { }} Disabled={true} />
+                    <Input<OpenXDA.Types.RemoteXDAMeter> Record={formMeter} Field={'LocalAssetKey'} Label={'Local Meter Key'} Valid={() => true} Setter={() => { }} Disabled={true} />
                     <Input<OpenXDA.Types.RemoteXDAMeter> Record={formMeter} Field={'LocalAlias'} Label={'Local Alias'} Valid={() => true} Setter={() => { }} Disabled={true} />
                 </div>
                 <div className="col" style={{ width: '50%', float: "right" }}>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteXDAInstanceForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteXDAInstanceForm.tsx
@@ -205,7 +205,7 @@ export default function RemoteXDAInstanceForm(props: IProps) {
                 <form>
                     <div className="col" style={{ width: '50%', float: "left" }}>
                         <Input<OpenXDA.Types.RemoteXDAInstance> Record={formInstance} Field={'Name'} Label={'Name'} Feedback={"A name of less than 200 characters is required."} Valid={valid} Setter={setFormInstance} />
-                        <Input<OpenXDA.Types.RemoteXDAInstance> Record={formInstance} Field={'Address'} Label={'Address'} Feedback={"An address of less than 200 characters is required."} Valid={valid} Setter={setFormInstance} />
+                        <Input<OpenXDA.Types.RemoteXDAInstance> Record={formInstance} Field={'Address'} Label={'URL'} Feedback={"A URL of less than 200 characters is required."} Valid={valid} Setter={setFormInstance} />
                         <Input<OpenXDA.Types.RemoteXDAInstance> Record={formInstance} Field={'Frequency'} Label={'Frequency'} Feedback={"A frequency that is a valid cron format is required."} Valid={valid} Setter={setFormInstance} Help={'In order of minutes, hours, day of the month, month, weekday. For example, a frequency of every midnight would be * 0 * * *'} />
                     </div>
                     <div className="col" style={{ width: '50%', float: "right" }}>
@@ -262,7 +262,7 @@ export default function RemoteXDAInstanceForm(props: IProps) {
                     Show={showUserSearch}
                     Type={'single'}
                     Columns={[
-                        { key: 'Name', field: 'Name', label: 'Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
+                        { key: 'Name', field: 'Name', label: 'Username', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'Email', field: 'Email', label: 'Email', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'Scroll', label: '', headerStyle: { width: 17, padding: 0 }, rowStyle: { width: 0, padding: 0 } },
                     ]}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteXDAInstanceMain.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteXDAInstanceMain.tsx
@@ -122,7 +122,7 @@ const RemoteXDAInstanceMain: Application.Types.iByComponent = (props) => {
                 <Table<OpenXDA.Types.RemoteXDAInstance>
                     cols={[
                         { key: 'Name', field: 'Name', label: 'Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
-                        { key: 'Address', field: 'Address', label: 'URL Address', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
+                        { key: 'Address', field: 'Address', label: 'URL', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'Scroll', label: '', headerStyle: { width: 17, padding: 0 }, rowStyle: { width: 0, padding: 0 } }
                     ]}
                     tableClass="table table-hover"

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataOperations.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataOperations.tsx
@@ -69,16 +69,16 @@ const DataOperations: GlobalSC.BySettingsComponent = (props) => {
     React.useEffect(() => {
         const e: string[] = [];
         if (editnewSetting.AssemblyName == null || editnewSetting.AssemblyName.length === 0)
-            e.push('An AssemblyName is required')
+            e.push('An Assembly Name is required')
         if (editnewSetting.TypeName == null || editnewSetting.AssemblyName.length === 0)
-            e.push('An TypeName is required')
+            e.push('An Type Name is required')
         setErrors(e)
     }, [editnewSetting])
 
     const searchFields: Search.IField<OpenXDA.Types.DataOperation>[] = [
-        { key: 'AssemblyName', label: 'AssemblyName', type: 'string', isPivotField: false },
-        { key: 'TypeName', label: 'TypeName', type: 'string', isPivotField: false },
-        { key: 'LoadOrder', label: 'LoadOrder', type: 'number', isPivotField: false }
+        { key: 'AssemblyName', label: 'Assembly Name', type: 'string', isPivotField: false },
+        { key: 'TypeName', label: 'Type Name', type: 'string', isPivotField: false },
+        { key: 'LoadOrder', label: 'Load Order', type: 'number', isPivotField: false }
     ]
 
     if (status === 'error')

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataReaders.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataReaders.tsx
@@ -67,16 +67,16 @@ const DataReaders: GlobalSC.BySettingsComponent = (props) => {
     React.useEffect(() => {
         const e: string[] = [];
         if (editnewSetting.AssemblyName == null || editnewSetting.AssemblyName.length === 0)
-            e.push('An AssemblyName is required')
+            e.push('An Assembly Name is required')
         if (editnewSetting.TypeName == null || editnewSetting.AssemblyName.length === 0)
-            e.push('An TypeName is required')
+            e.push('An Type Name is required')
         setErrors(e)
     }, [editnewSetting])
 
     const searchFields: Search.IField<OpenXDA.Types.DataReader>[] = [
-        { key: 'AssemblyName', label: 'AssemblyName', type: 'string', isPivotField: false },
-        { key: 'TypeName', label: 'TypeName', type: 'string', isPivotField: false },
-        { key: 'LoadOrder', label: 'LoadOrder', type: 'number', isPivotField: false }
+        { key: 'AssemblyName', label: 'Assembly Name', type: 'string', isPivotField: false },
+        { key: 'TypeName', label: 'Type Name', type: 'string', isPivotField: false },
+        { key: 'LoadOrder', label: 'Load Order', type: 'number', isPivotField: false }
     ]
 
     if (status === 'error')

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/Setting.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/Setting.tsx
@@ -84,9 +84,9 @@ function Setting(props: IProps) {
     }, [editnewSetting])
 
     const searchFields: Search.IField<SystemCenter.Types.Setting>[] = [
-        { key: 'Name', label: 'Name', type: 'string', isPivotField: false },
+        { key: 'Name', label: 'Setting Name', type: 'string', isPivotField: false },
         { key: 'DefaultValue', label: 'Default Value', type: 'string', isPivotField: false },
-        { key: 'Value', label: 'Value', type: 'string', isPivotField: false }
+        { key: 'Value', label: 'Current Value', type: 'string', isPivotField: false }
     ]
 
     if (status === 'error')
@@ -99,7 +99,7 @@ function Setting(props: IProps) {
             <LoadingScreen Show={status === 'loading'} />
             <div style={{ width: '100%', height: '100%' }}>
                 <SearchBar<SystemCenter.Types.Setting> CollumnList={searchFields} SetFilter={(flds) => dispatch(props.SettingsSlice.DBSearch({ filter: flds, sortField, ascending }))}
-                    Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
+                    Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Setting Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
                     ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Settings'}
                     GetEnum={() => {
                         return () => { }
@@ -168,7 +168,7 @@ function Setting(props: IProps) {
                             Valid={field => editnewSetting.Name != null && editnewSetting.Name.length > 0 && allSettings.findIndex(s => s.Name === editnewSetting.Name && s.ID !== editnewSetting.ID) < 0}
                             Setter={(record) => { setEditNewSetting(record); setHasChanged(true); }}
                         />
-                        <TextArea<SystemCenter.Types.Setting> Record={editnewSetting} Field={'Value'} Label='Value' Valid={field => true}
+                        <TextArea<SystemCenter.Types.Setting> Record={editnewSetting} Field={'Value'} Label='Current Value' Valid={field => true}
                             Setter={(record) => { setEditNewSetting(record); setHasChanged(true); }}
                             Rows={1}
                         />

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/ByUser.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/ByUser.tsx
@@ -34,10 +34,9 @@ import { IUserAccount } from '../Types';
 import moment from 'moment';
 
 const defaultSearchcols: Search.IField<Application.Types.iUserAccount>[] = [
-    { label: 'Name', key: 'Name', type: 'string', isPivotField: false },
+    { label: 'Username', key: 'Name', type: 'string', isPivotField: false },
     { label: 'First Name', key: 'FirstName', type: 'string', isPivotField: false },
     { label: 'Last Name', key: 'LastName', type: 'string', isPivotField: false },
-    { label: 'Location', key: 'Location', type: 'string', isPivotField: false },
     { label: 'Phone', key: 'Phone', type: 'string', isPivotField: false },
     { label: 'Email', key: 'Email', type: 'string', isPivotField: false },
 ];
@@ -175,7 +174,7 @@ const ByUser: Application.Types.iByComponent = (props) => {
             <div style={{ width: '100%', height: 'calc( 100% - 136px)' }}>
                 <Table<IUserAccount>
                     cols={[
-                        { key: 'DisplayName', field: 'DisplayName', label: 'User Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
+                        { key: 'DisplayName', field: 'DisplayName', label: 'Username', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'FirstName', field: 'FirstName', label: 'First Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'LastName', field: 'LastName', label: 'Last Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         { key: 'Phone', field: 'Phone', label: 'Phone', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/UserForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/UserForm.tsx
@@ -134,11 +134,11 @@ function UserForm(props: IProps) {
             <form>
                 <div className="row">
                     <div className="col">
-                        <Input<IUserAccount> Record={props.UserAccount} Disabled={props.Edit} Label={'Name'} Field={'DisplayName'}
+                        <Input<IUserAccount> Record={props.UserAccount} Disabled={props.Edit} Label={'Username'} Field={'DisplayName'}
                             Feedback={'A Name of less than 200 characters is required.'}
                             Valid={field => validUserAccountField(props.UserAccount, field)} Setter={props.Setter} />
 
-                        <div className="row" style={{ position: 'absolute', top: 0, left: 100 }} hidden={props.UserAccount.Type == 'Database'}>
+                        <div className="row" style={{ position: 'absolute', top: 0, left: 130 }} hidden={props.UserAccount.Type == 'Database'}>
                             <span id="resolvingAccount" hidden={valid !== 'resolving'}><i style={{ height: 10, width: 10, color: 'grey' }}
                                 className="fa fa fa-spin fa-refresh"></i>&nbsp;<em className="small">Resolving account details...</em></span>
                             <span id="accountValid" hidden={valid !== 'valid'}><i style={{ height: 20, width: 20, color: 'green' }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ByValueListGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ByValueListGroup.tsx
@@ -131,7 +131,7 @@ const ValueListGroups: Application.Types.iByComponent = (props) => {
                 <Table< SystemCenter.Types.ValueListGroup>
                     cols={[
                         { key: 'Name', label: 'Name', field: 'Name', headerStyle: { width: '15%' }, rowStyle: { width: '15%' } },
-                        { key: 'Description', field: 'Description',label: 'Description/Comments', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
+                        { key: 'Description', field: 'Description',label: 'Description', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' } },
                         {
                             key: 'Items', label: 'Items', field: 'Items', headerStyle: { width: '10%' }, rowStyle: { width: '10%' },
                             content: (item, key, style) => items.filter(i => i.GroupID == item.ID).length


### PR DESCRIPTION
`Asset Groups`
 - Removed `Users` from `Info` tab

`Data Files`
 - Changed column name to `File Path` to match filter

`Remote openXDA Instances`
 - Changed all labels to `URL`

`External Databases`
 - Changed all `Name` labels to `Table Name`
 - Changed filter label to `External DB` (added space)

`Application Categories`
 - Changed filter label to `Sort Order`
 - Removed `Value` filter

`Value Lists`
 - Changed labels to `Description`

`SystemCenter`, `OpenXDA`, & `MiMD`
 - Changed filter label to `Setting Name`
 - Changed labels to `Current Value`

`OpenXDA Data Operations` & `OpenXDA Data Readers`
 - Changed filter labels to `Assembly Name`, `Type Name`, and `Load Order`

`SSO Applications`
 - Changed filter labels to `Application Name` and `Node ID`

`Users`
 - Changed labels to `Username`
 - Removed `Location` filter

Ticket 1322
 - Fixed `Make` and `Model` column labels

Additional messaging fixes for consistency (i.e. change `AssetGroup` to `Asset Group`)