### PR TITLE
Search feedback

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ByApplicationCategory.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ByApplicationCategory.tsx
@@ -104,7 +104,7 @@ const ByApplicationCategory: Application.Types.iByComponent = (props) => {
         <div style={{ width: '100%', height: '100%' }}>
             <SearchBar<ApplicationCategory> CollumnList={searchFields} SetFilter={(flds) => dispatch(ApplicationCategorySlice.DBSearch({ filter: flds, sortField, ascending }))} Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Name', type: 'string', isPivotField: false }}
                 Width={'50%'} Label={'Search'}
-                ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Application Categories'}
+                ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Application Categorie(s)'}
                 GetEnum={() => {
                         return () => { }
                     }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationManagment/ApplicationNode.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationManagment/ApplicationNode.tsx
@@ -89,7 +89,7 @@ const ByApplicationNode: Application.Types.iByComponent = (props) => {
             <div style={{ width: '100%', height: '100%' }}>
                 <SearchBar<Application.Types.iApplicationNode> CollumnList={searchFields} SetFilter={(flds) => dispatch(ApplicationNodeSlice.DBSearch({ filter: flds, sortField, ascending }))}
                     Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Application Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
-                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Applications'}
+                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Application(s)'}
                     GetEnum={() => {
                         return () => { }
                     }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Customer/ByCustomer.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Customer/ByCustomer.tsx
@@ -118,7 +118,7 @@ const ByCustomer: Application.Types.iByComponent = (props) => {
     return (
         <div style={{ width: '100%', height: '100%' }}>
             <SearchBar<OpenXDA.Types.Customer> CollumnList={filterableList} SetFilter={(flds) => setSearch(flds)} Direction={'left'} defaultCollumn={DefaultSearchField.Customer as Search.IField<OpenXDA.Types.Customer>} Width={'50%'} Label={'Search'}
-                ShowLoading={cState == 'loading'} ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Customers'}
+                ShowLoading={cState == 'loading'} ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Customer(s)'}
                 GetEnum={(setOptions, field) => {
                     let handle = null;
                    

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DB/DBCleanup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DB/DBCleanup.tsx
@@ -100,7 +100,7 @@ const DBCleanup: Application.Types.iByComponent = (props) => {
             <div style={{ width: '100%', height: '100%' }}>
                 <SearchBar<DBCleanup> CollumnList={searchFields} SetFilter={(flds) => dispatch(DBCleanupSlice.DBSearch({ filter: flds, sortField, ascending }))}
                     Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
-                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' DB Cleanups'}
+                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Database Cleanup(s)'}
                     GetEnum={() => {
                         return () => { }
                     }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
@@ -154,7 +154,7 @@ const DeviceHealthReport: Application.Types.iByComponent = (props) => {
     return (
         <div style={{ width: '100%', height: '100%' }}>
             <SearchBar<SCGlobal.DeviceHealthReport> CollumnList={filterableList} SetFilter={(flds) => setSearch(flds)} Direction={'left'} defaultCollumn={standardSearch} Width={'50%'} Label={'Search'}
-                ShowLoading={searchState == 'Loading'} ResultNote={searchState == 'Error' ? 'Could not complete Search' : 'Found ' + data.length + ' Meters'}
+                ShowLoading={searchState == 'Loading'} ResultNote={searchState == 'Error' ? 'Could not complete Search' : 'Found ' + data.length + ' Meter(s)'}
                 GetEnum={(setOptions, field) => {
                     let handle = null;
                     if (field.type != 'enum' || field.enum == undefined || field.enum.length != 1)

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ByExternalDB.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ByExternalDB.tsx
@@ -90,7 +90,7 @@ const ByExternalDB: Application.Types.iByComponent = (props) => {
                 Width={'50%'}
                 Label={'Search'}
                 ShowLoading={searchState == 'loading'}
-                ResultNote={searchState == 'error' ? 'Could not complete Search' : 'Found ' + searchResults.length + ' External Database Tables'}
+                ResultNote={searchState == 'error' ? 'Could not complete Search' : 'Found ' + searchResults.length + ' External Database Table(s)'}
                 GetEnum={(setOptions, field) => {
                     let handle = null;
                     if (field.type != 'enum' || field.enum == undefined || field.enum.length != 1)

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/MagDurCurves/ByMagDurCurve.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/MagDurCurves/ByMagDurCurve.tsx
@@ -87,7 +87,7 @@ const ByMagDurCurve: Application.Types.iByComponent = (props) => {
                 defaultCollumn={{ key: 'Name', isPivotField: false, label: 'Name', type: 'string' }}
                 Width={'50%'} Label={'Search'}
                 ShowLoading={cState == 'loading'}
-                ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Curves'}
+                ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Curve(s)'}
             >
                 <li className="nav-item" style={{ width: '15%', paddingRight: 10 }}>
                     <fieldset className="border" style={{ padding: '10px', height: '100%' }}>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/Advanced/MeterDataMerge.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/Advanced/MeterDataMerge.tsx
@@ -203,7 +203,7 @@ export default function DataMergeWindow(props: {
     }
 
     const getResultNote = () => searchState !== "Error"
-        ? `Found ${meters.length} Meters`
+        ? `Found ${meters.length} Meter(s)`
         : "Could not complete Search";
 
     const mergeMeterName = (mergeMeter !== undefined)

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/MultipleAssetsPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/MultipleAssetsPage.tsx
@@ -62,7 +62,7 @@ export default function MultipleAssetsPage(props: IProps) {
         tableBody = (
             <div style={{ width: '100%', height: '200px' }}>
                 <div style={{ height: '40px', marginLeft: 'auto', marginRight: 'auto', marginTop: 'calc(50% - 20 px)' }}>
-                    <ServerErrorIcon Show={true} Size={40} Label={currentAsset == null ? 'No Assets Found for this Meter.' : 'A Server Error Occurred. Please Reload the Application'} />
+                    <ServerErrorIcon Show={true} Size={40} Label={currentAsset == null ? 'No Assets found for this Meter.' : 'A Server Error Occurred. Please Reload the Application.'} />
                 </div>
             </div>);
     else

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ProcessedFile/ByFile.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ProcessedFile/ByFile.tsx
@@ -105,7 +105,7 @@ const ByFile: Application.Types.iByComponent = (props) => {
         <div style={{ width: '100%', height: '100%' }}>
             <LoadingScreen Show={showWarning == 'loading'} />
             <SearchBar<OpenXDA.Types.DataFile> CollumnList={filterableList} SetFilter={(flds) => setSearch(flds)} Direction={'left'} defaultCollumn={DefaultSearchField.DataFile as Search.IField<OpenXDA.Types.DataFile>} Width={'100%'} Label={'Search'}
-                ShowLoading={cState == 'loading'} ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Data Files'}
+                ShowLoading={cState == 'loading'} ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Data File(s)'}
                 GetEnum={(setOptions, field) => {
                     let handle = null;
                    

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteXDAInstanceMain.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/RemoteXDA/RemoteXDAInstanceMain.tsx
@@ -86,7 +86,7 @@ const RemoteXDAInstanceMain: Application.Types.iByComponent = (props) => {
                 Width={'50%'}
                 Label={'Search'}
                 ShowLoading={searchState == 'loading'}
-                ResultNote={searchState == 'error' ? 'Could not complete Search' : 'Found ' + searchResults.length + ' Remote openXDA Intances'}
+                ResultNote={searchState == 'error' ? 'Could not complete Search' : 'Found ' + searchResults.length + ' Remote openXDA Intance(s)'}
                 GetEnum={(setOptions, field) => {
                     let handle = null;
                     if (field.type != 'enum' || field.enum == undefined || field.enum.length != 1)

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SEBrowser/ByWidgetCategory.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SEBrowser/ByWidgetCategory.tsx
@@ -75,7 +75,7 @@ const ByWidgetCategory: Application.Types.iByComponent = (props) => {
                 defaultCollumn={{ key: 'Name', isPivotField: false, label: 'Name', type: 'string' }}
                 Width={'50%'} Label={'Search'}
                 ShowLoading={cState == 'loading'}
-                ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Tabs'}
+                ResultNote={cState == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Tab(s)'}
             >
                 <li className="nav-item" style={{ width: '15%', paddingRight: 10 }}>
                     <fieldset className="border" style={{ padding: '10px', height: '100%' }}>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataOperations.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataOperations.tsx
@@ -83,7 +83,7 @@ const DataOperations: GlobalSC.BySettingsComponent = (props) => {
 
     if (status === 'error')
         return <div style={{ width: '100%', height: '100%' }}>
-            <ServerErrorIcon Show={true} Label={'A Server Error Occurred. Please Reload the Application'} />
+            <ServerErrorIcon Show={true} Label={'A Server Error Occurred. Please Reload the Application.'} />
         </div>;
 
     return (

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataOperations.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataOperations.tsx
@@ -92,7 +92,7 @@ const DataOperations: GlobalSC.BySettingsComponent = (props) => {
             <div style={{ width: '100%', height: '100%' }}>
                 <SearchBar<OpenXDA.Types.DataOperation> CollumnList={searchFields} SetFilter={(flds) => dispatch(DataOperationSlice.DBSearch({ filter: flds, sortField, ascending }))}
                     Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
-                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Settings'}
+                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Data Operation(s)'}
                     GetEnum={() => {
                         return () => { }
                     }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataReaders.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/DataReaders.tsx
@@ -90,7 +90,7 @@ const DataReaders: GlobalSC.BySettingsComponent = (props) => {
             <div style={{ width: '100%', height: '100%' }}>
                 <SearchBar<OpenXDA.Types.DataReader> CollumnList={searchFields} SetFilter={(flds) => dispatch(DataReaderSlice.DBSearch({ filter: flds, sortField, ascending }))}
                     Direction={'left'} defaultCollumn={{ key: 'AssemblyName', label: 'Assembly Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
-                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Settings'}
+                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Data Reader(s)'}
                     GetEnum={() => {
                         return () => { }
                     }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/Setting.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Settings/Setting.tsx
@@ -100,7 +100,7 @@ function Setting(props: IProps) {
             <div style={{ width: '100%', height: '100%' }}>
                 <SearchBar<SystemCenter.Types.Setting> CollumnList={searchFields} SetFilter={(flds) => dispatch(props.SettingsSlice.DBSearch({ filter: flds, sortField, ascending }))}
                     Direction={'left'} defaultCollumn={{ key: 'Name', label: 'Setting Name', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
-                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Settings'}
+                    ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Setting(s)'}
                     GetEnum={() => {
                         return () => { }
                     }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/ByUser.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/ByUser.tsx
@@ -145,7 +145,7 @@ const ByUser: Application.Types.iByComponent = (props) => {
             <LoadingScreen Show={pageStatus === 'loading'} />
             <SearchBar<IUserAccount> CollumnList={filterableList} SetFilter={(flds) => dispatch(UserAccountSlice.DBSearch({ sortField, ascending, filter: flds }))}
                 Direction={'left'} defaultCollumn={{ label: 'Last Name', key: 'LastName', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
-                ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' User Accounts'}
+                ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' User Account(s)'}
                 GetEnum={(setOptions, field) => {
 
                     if (field.type !== 'enum' || field.enum === undefined || field.enum.length !== 1)

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/UserGroup/ByUserGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/UserGroup/ByUserGroup.tsx
@@ -87,7 +87,7 @@ const ByUser: Application.Types.iByComponent = (props) => {
             <LoadingScreen Show={pageStatus === 'loading'} />
             <SearchBar<ISecurityGroup> CollumnList={defaultSearchcols} SetFilter={(flds) => dispatch(SecurityGroupSlice.DBSearch({ filter: flds }))}
                 Direction={'left'} defaultCollumn={{ label: 'Name', key: 'DisplayName', type: 'string', isPivotField: false }} Width={'50%'} Label={'Search'}
-                ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Groups'}
+                ShowLoading={searchStatus === 'loading'} ResultNote={searchStatus === 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' User Group(s)'}
                 GetEnum={() => {
                     return () => { }
                 }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ByValueListGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ByValueListGroup.tsx
@@ -95,7 +95,7 @@ const ValueListGroups: Application.Types.iByComponent = (props) => {
                 Width={'50%'}
                 Label={'Search'}
                 ShowLoading={status == 'loading'}
-                ResultNote={status == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Groups'}
+                ResultNote={status == 'error' ? 'Could not complete Search' : 'Found ' + data.length + ' Value List(s)'}
                 GetEnum={(setOptions, field) => {
                     let handle = null;
                     if (field.type != 'enum' || field.enum == undefined || field.enum.length != 1)


### PR DESCRIPTION
More UI fixes.
- Add `( )` to search feedback messages for consistency throughout System Center.
- Update object names in search feedback messages in some cases.
- Add missing period to the end of warning messages.