### PR TITLE
Channel updates

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
@@ -58,7 +58,6 @@ const ChannelScalingForm = (props: IProps) => {
     const mcStatus = useAppSelector(MeasurementCharacteristicSlice.Status) as Application.Types.Status;
     const [status, setStatus] = React.useState <Application.Types.Status>('idle');
     const [hover, setHover] = React.useState<( 'Reset' | 'None' | 'Replace' | 'Adjust' )>('None');
-    const [changed, setChanged] = React.useState<boolean>(false);
 
     // Constants
     const ScalingTypes: ChannelScalingType[] = [
@@ -91,12 +90,9 @@ const ChannelScalingForm = (props: IProps) => {
         setMultiplier(multip);
     }, [])
     React.useEffect(() => {
-        if (props.Key == undefined)
-            return;
-        if (changed)
             localStorage.setItem('SystemCenter.ChannelScaling.' + props.Key + '.V', multiplier.Voltage.toString());
             localStorage.setItem('SystemCenter.ChannelScaling.' + props.Key + '.I', multiplier.Current.toString());
-    }, [multiplier]);
+    }, [multiplier.Voltage, multiplier.Current]);
 
     React.useEffect(() => {
         if (pStatus == 'unintiated' || pStatus == 'changed')
@@ -184,7 +180,6 @@ const ChannelScalingForm = (props: IProps) => {
                 <div className="col-3">
                     <Input<IMultiplier> Record={multiplier} AllowNull={true} Type={'number'} Label={'Voltage Multiplier'} Field={'Voltage'} Size={'small'} Setter={(r) => {
                         setMultiplier({ Voltage: r.Voltage ?? 1, Current: r.Current ?? 1 });
-                    setChanged(true);
                     }} Valid={(f) => true} />
                 </div>
                 <div className="col-3">
@@ -194,7 +189,6 @@ const ChannelScalingForm = (props: IProps) => {
                         AllowNull={true}
                         Field={'Current'} Setter={(r) => {
                             setMultiplier({ Voltage: r.Voltage ?? 1, Current: r.Current ?? 1 });
-                            setChanged(true);
                         }} Valid={(f) => true} />   
                 </div>
                 </div>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
@@ -93,7 +93,7 @@ const ChannelScalingForm = (props: IProps) => {
     React.useEffect(() => {
         if (props.Key == undefined)
             return;
-        if (multiplier.Voltage != 1)
+        if (changed)
             localStorage.setItem('SystemCenter.ChannelScaling.' + props.Key + '.V', multiplier.Voltage.toString());
         if (multiplier.Current != 1)
             localStorage.setItem('SystemCenter.ChannelScaling.' + props.Key + '.I', multiplier.Current.toString());

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
@@ -95,7 +95,6 @@ const ChannelScalingForm = (props: IProps) => {
             return;
         if (changed)
             localStorage.setItem('SystemCenter.ChannelScaling.' + props.Key + '.V', multiplier.Voltage.toString());
-        if (multiplier.Current != 1)
             localStorage.setItem('SystemCenter.ChannelScaling.' + props.Key + '.I', multiplier.Current.toString());
     }, [multiplier]);
 
@@ -238,26 +237,26 @@ const ChannelScalingForm = (props: IProps) => {
             </div>
             <div className="card-footer">
                 <div className="btn-group mr-2">
-                    <button className={"btn btn-primary pull-right" + (!changed ? ' disabled' : '')} onClick={() => { if(changed) useReplacedMultiplier(); }}
+                    <button className={"btn btn-primary pull-right" + ((multiplier.Voltage == 1 && multiplier.Current == 1) ? ' disabled' : '')} onClick={() => { if(multiplier.Voltage  != 1 || multiplier.Current != 1) useReplacedMultiplier(); }}
                         onMouseEnter={() => setHover('Replace')} onMouseLeave={() => setHover('None')} data-tooltip={"rep"}
                     >Replace Multipliers</button>
-                    <ToolTip Show={hover == 'Replace' && (!changed)} Position={'top'} Theme={'dark'} Target={"rep"}>
+                    <ToolTip Show={hover == 'Replace' && (multiplier.Voltage == 1 || multiplier.Current == 1)} Position={'top'} Theme={'dark'} Target={"rep"}>
                         <p> There are no changes to be applied. </p>
                     </ToolTip>
                 </div>
                 <div className="btn-group mr-2">
-                    <button className={"btn btn-primary pull-right" + (!changed ? ' disabled' : '')} onClick={() => { if (changed) useAdjustedMultiplier(); }}
+                    <button className={"btn btn-primary pull-right" + ((multiplier.Voltage == 1 && multiplier.Current == 1) ? ' disabled' : '')} onClick={() => { if (multiplier.Voltage != 1 || multiplier.Current != 1) useAdjustedMultiplier(); }}
                         onMouseEnter={() => setHover('Adjust')} onMouseLeave={() => setHover('None')} data-tooltip={"adj"}
                     >Adjust Multipliers</button>
-                    <ToolTip Show={hover == 'Adjust' && (changed)} Position={'top'} Theme={'dark'} Target={"adj"}>
+                    <ToolTip Show={hover == 'Adjust' && (multiplier.Voltage != 1 || multiplier.Current != 1)} Position={'top'} Theme={'dark'} Target={"adj"}>
                         <p> There are no changes to be applied. </p>
                     </ToolTip>
                 </div>
                 <div className="btn-group mr-2">
-                    <button className={"btn btn-default" + (!changed ? ' disabled' : '')} onClick={() => { if (changed) initializeWrappers(); }}
+                    <button className={"btn btn-default" + ((multiplier.Voltage == 1 && multiplier.Current == 1) ? ' disabled' : '')} onClick={() => { if (multiplier.Voltage != 1 || multiplier.Current != 1) initializeWrappers(); }}
                         onMouseEnter={() => setHover('Reset')} onMouseLeave={() => setHover('None')} data-tooltip={"res"}
                     >Clear Changes</button>
-                    <ToolTip Show={hover == 'Reset' && (changed)} Position={'top'} Theme={'dark'} Target={"res"}>
+                    <ToolTip Show={hover == 'Reset' && (multiplier.Voltage == 1 || multiplier.Current == 1)} Position={'top'} Theme={'dark'} Target={"res"}>
                         <p> All changes will be lost. </p>
                     </ToolTip>
                 </div>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterEventChannel.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterEventChannel.tsx
@@ -26,11 +26,10 @@ import * as _ from 'lodash';
 import { Application, OpenXDA as GemstoneOpenXDA} from '@gpa-gemstone/application-typings';
 import { PhaseSlice, MeasurmentTypeSlice } from '../Store/Store'
 import { useAppSelector, useAppDispatch } from '../hooks';
-import { LoadingIcon, ServerErrorIcon, ToolTip, Warning } from '@gpa-gemstone/react-interactive';
+import { ConfigurableTable, LoadingIcon, ServerErrorIcon, ToolTip, Warning } from '@gpa-gemstone/react-interactive';
 import { Input, Select } from '@gpa-gemstone/react-forms';
 import { AssetAttributes } from '../AssetAttribute/Asset';
 import { CrossMark, TrashCan } from '@gpa-gemstone/gpa-symbols';
-import Table from '@gpa-gemstone/react-table';
 import { OpenXDA } from '../global';
 import { SelectAscending, SelectSortKey, SelectEventChannels, SelectEventChannelStatus, SelectMeterID, dBAction } from '../Store/EventChannelSlice';
 import { FetchChannels } from '../Store/EventChannelSlice';
@@ -238,10 +237,10 @@ const MeterEventChannelWindow = (props: IProps) => {
         </div>
         <div className="card-body">
             <div style={{ width: '100%', height: window.innerHeight - 420 }}>
-                <Table<OpenXDA.EventChannel>
+                <ConfigurableTable<OpenXDA.EventChannel>
                     cols={[
                         {
-                            key: 'SourceIndices', field: 'SourceIndices', label: 'Channel', headerStyle: { width: '5%' }, rowStyle: { width: '5%' },
+                            key: 'SourceIndices', field: 'SourceIndices', label: 'Channel', headerStyle: { width: '7%' }, rowStyle: { width: '7%' },
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'SourceIndices'} Label={''} Setter={(r) => createChange(r, 'SourceIndices')} Valid={(f) => isValid(f,c)} />
                         },
                         {
@@ -249,7 +248,7 @@ const MeterEventChannelWindow = (props: IProps) => {
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'Name'} Label={''} Setter={(r) => createChange(r, 'Name')} Valid={(f) => isValid(f, c)} />
                         },
                         {
-                            key: 'Description', field: 'Description', label: 'Desc', headerStyle: { width: '25%' }, rowStyle: { width: '25%' },
+                            key: 'Description', field: 'Description', label: 'Description', headerStyle: { width: '20%' }, rowStyle: { width: '20%' },
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'Description'} Label={''} Setter={(r) => createChange(r, 'Description')} Valid={(f) => isValid(f, c)} />
                         },
                         {
@@ -259,36 +258,38 @@ const MeterEventChannelWindow = (props: IProps) => {
                         {
                             key: 'Phase', field: 'Phase', label: 'Phase', headerStyle: { width: '10%' }, rowStyle: { width: '10%' },
                             content: (c) => <Select Record={c} Field={'PhaseID'} Label={''} Options={phases.map(d => ({ Label: d.Name, Value: d.ID.toString() }))} Setter={(r) => createChange(r, 'PhaseID')} />
-                            
                         },
                         {
-                            key: 'Adder', field: 'Adder', label: 'Adder', headerStyle: { width: '5%' }, rowStyle: { width: '5%' },
+                            key: 'Adder', field: 'Adder', label: 'Adder', headerStyle: { width: '7%' }, rowStyle: { width: '7%' },
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'Adder'} Type={'number'} Label={''} Setter={(r) => createChange(r, 'Adder')} Valid={(f) => isValid(f, c)} />
                         },
                         {
-                            key: 'Multiplier', field: 'Multiplier', label: 'Multiplier', headerStyle: { width: '5%' }, rowStyle: { width: '5%' },
+                            key: 'Multiplier', field: 'Multiplier', label: 'Multiplier', headerStyle: { width: '7%' }, rowStyle: { width: '7%' },
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'Multiplier'} Type={'number'} Label={''} Setter={(r) => createChange(r, 'Multiplier')} Valid={(f) => isValid(f, c)} />
                         },
                         {
-                            key: 'Asset', field: 'Asset', label: 'Asset', headerStyle: { width: '10%' }, rowStyle: { width: '10%' },
+                            key: 'Asset', field: 'Asset', label: 'Asset', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' },
                             content: (c) => <Select Record={c} Field={'AssetID'} Label={''} Options={assets.map(d => ({ Label: d.AssetKey, Value: d.ID.toString() }))} Setter={(r) => createChange(r, 'AssetID')} />
                         },
                         {
-                            key: 'ConnectionPriority', field: 'ConnectionPriority', label: 'Con.', headerStyle: { width: '5%' }, rowStyle: { width: '5%' },
+                            key: 'ConnectionPriority', field: 'ConnectionPriority', label: 'Priority', headerStyle: { width: '7%' }, rowStyle: { width: '7%' },
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'ConnectionPriority'} Type={'number'} Label={''} Setter={(r) => createChange(r, 'ConnectionPriority')} Valid={(f) => isValid(f, c)} />
                         },
                         {
-                            key: 'Remove', label: '', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' },
+                            key: 'Remove', label: '', headerStyle: { width: '3%' }, rowStyle: { width: '3%' },
                             content: (c) => <button className="btn btn-sm" onClick={(e) => setRemoveRecord(c)}><span>{TrashCan}</span></button>
                         },
                         { key: 'Scroll', label: '', headerStyle: { width: 17, padding: 0 }, rowStyle: { width: 0, padding: 0 } },
 
                     ]}
+                    defaultColumns={["SourceIndices", "Name", "Phase", "MeasurementType", "Adder", "Multiplier", "Description", "Asset", "ConnectionPriority", "Remove", "Scroll"]}
+                    requiredColumns={["Name", "Remove", "Scroll"]}
+                    localStorageKey="MeterEventChannelConfigTable"
                     tableClass="table table-hover"
                     data={data.map(c => replicateChanges(c))}
                     sortKey={sortKey}
                     ascending={ascending}
-                        onSort={(d) => {
+                    onSort={(d) => {
 
                             if (d.colKey === "Scroll" || d.colKey == 'Remove')
                                 return;
@@ -299,6 +300,7 @@ const MeterEventChannelWindow = (props: IProps) => {
                                 dispatch(FetchChannels({ sortField: d.colField, ascending: true, meterId: props.Meter.ID }));
                         }}
                     onClick={() => { }}
+                    tableStyle={{ padding: 0, width: 'calc(100%)', tableLayout: 'fixed'}}
                     theadStyle={{ fontSize: 'smaller', display: 'table', tableLayout: 'fixed', width: '100%' }}
                     tbodyStyle={{ display: 'block', overflowY: 'scroll', maxHeight: window.innerHeight - 500, width: '100%' }}
                     rowStyle={{ fontSize: 'smaller', display: 'table', tableLayout: 'fixed', width: '100%' }}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterEventChannel.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterEventChannel.tsx
@@ -244,11 +244,11 @@ const MeterEventChannelWindow = (props: IProps) => {
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'SourceIndices'} Label={''} Setter={(r) => createChange(r, 'SourceIndices')} Valid={(f) => isValid(f,c)} />
                         },
                         {
-                            key: 'Name', field: 'Name', label: 'Name', headerStyle: { width: '15%' }, rowStyle: { width: '15%' },
+                            key: 'Name', field: 'Name', label: 'Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' },
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'Name'} Label={''} Setter={(r) => createChange(r, 'Name')} Valid={(f) => isValid(f, c)} />
                         },
                         {
-                            key: 'Description', field: 'Description', label: 'Description', headerStyle: { width: '20%' }, rowStyle: { width: '20%' },
+                            key: 'Description', field: 'Description', label: 'Description', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' },
                             content: (c) => <Input<OpenXDA.EventChannel> Record={c} Field={'Description'} Label={''} Setter={(r) => createChange(r, 'Description')} Valid={(f) => isValid(f, c)} />
                         },
                         {

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
@@ -348,24 +348,24 @@ export default function ChannelPage(props: IProps) {
                         key: 'Name', label: 'Name', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Name'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
                     },
                     {
-                        key: 'MeasurementType', label: 'Type', headerStyle: { width: '13%' }, rowStyle: { width: '13%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementType'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementTypes.map((t) => ({ Value: t, Label: t }))} />
+                        key: 'MeasurementType', label: 'Type', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementType'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementTypes.map((t) => ({ Value: t, Label: t }))} />
                     },
                     {
-                        key: 'MeasurementCharacteristic', label: 'Char', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementCharacteristic'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementCharacteristics.map((t) => ({ Value: t, Label: t }))} />
+                        key: 'MeasurementCharacteristic', label: 'Char', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementCharacteristic'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementCharacteristics.map((t) => ({ Value: t, Label: t }))} />
                     },
                     {
-                        key: 'Phase', label: 'Phase', headerStyle: { width: '13%' }, rowStyle: { width: '13%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'Phase'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.Phases.map((t) => ({ Value: t, Label: t }))} />
+                        key: 'Phase', label: 'Phase', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'Phase'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.Phases.map((t) => ({ Value: t, Label: t }))} />
                     },
-                    { key: 'SamplesPerHour', label: 'Sph.', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'SamplesPerHour'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
-                    { key: 'PerUnitValue', label: 'Per Unit', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'PerUnitValue'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
-                    { key: 'HarmonicGroup', label: 'Harm', headerStyle: { width: '5%' }, rowStyle: { width: '5%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'HarmonicGroup'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
-                    { key: 'Adder', label: 'Adder', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Adder'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
-                    { key: 'Multiplier', label: 'Multiplier', headerStyle: { width: '8%' }, rowStyle: { width: '8%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Multiplier'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
+                    { key: 'SamplesPerHour', label: 'Sph.', headerStyle: { width: '7%' }, rowStyle: { width: '7%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'SamplesPerHour'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
+                    { key: 'PerUnitValue', label: 'Per Unit', headerStyle: { width: '7%' }, rowStyle: { width: '7%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'PerUnitValue'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
+                    { key: 'HarmonicGroup', label: 'Harm', headerStyle: { width: '7%' }, rowStyle: { width: '7%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'HarmonicGroup'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
+                    { key: 'Adder', label: 'Adder', headerStyle: { width: '7%' }, rowStyle: { width: '7%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Adder'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
+                    { key: 'Multiplier', label: 'Multiplier', headerStyle: { width: '7%' }, rowStyle: { width: '7%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Multiplier'} Type={'number'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} /> },
                     {
-                        key: 'Description', label: 'Description', headerStyle: { width: 'calc(24%-6px)' }, rowStyle: { width: 'calc(24%-6px)' }, content: (item) => <TextArea<OpenXDA.Types.Channel> Field={'Description'} Rows={2} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
+                        key: 'Description', label: 'Description', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' }, content: (item) => <TextArea<OpenXDA.Types.Channel> Field={'Description'} Rows={2} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
                     },
                     { key: 'DeleteButton', label: '', headerStyle: { width: '3%' }, rowStyle: { width: '3%', paddingTop: 36, paddingBottom: 36 }, content: (item, field, key, style, index) => <button className="btn btn-sm" onClick={(e) => deleteChannel(index)}><span>{TrashCan}</span></button> },
-                    { key: 'Scroll', label: '', headerStyle: { width: '5px' }, rowStyle: { width: '0px' }, content: () => null }
+                    { key: 'Scroll', label: '', headerStyle: { width: '5px', padding: 0 }, rowStyle: { width: '0px', padding: 0 }, content: () => null }
                 ]}
                     defaultColumns={["Series", "Name", "Phase", "Adder", "Multiplier", "Description", "DeleteButton", "Scroll"]}
                     requiredColumns={["Name", "DeleteButton", "Scroll"]}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
@@ -345,7 +345,7 @@ export default function ChannelPage(props: IProps) {
                         }} Label={''} Valid={() => true}/>
                     },
                     {
-                        key: 'Name', label: 'Name', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Name'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
+                        key: 'Name', label: 'Name', headerStyle: { width: 'auto' }, rowStyle: { width: 'auto' }, content: (item) => <Input<OpenXDA.Types.Channel> Field={'Name'} Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />
                     },
                     {
                         key: 'MeasurementType', label: 'Type', headerStyle: { width: '10%' }, rowStyle: { width: '10%' }, content: (item) => <Select<OpenXDA.Types.Channel> Field={'MeasurementType'} Record={item} Setter={(ch) => editChannel(ch)} Label={''} Options={OpenXDA.Lists.MeasurementTypes.map((t) => ({ Value: t, Label: t }))} />


### PR DESCRIPTION
ticket_1442
Update the Meter > Event Channels tab to use `ConfigurableTable` and adjust column widths for smaller screens.
Set width to `auto` for some fields in Event Channels and NMW Channel Page so the columns fill in space by hidden columns.
Fix issue in Channel Scaling Form that did not update local storage when CT/PT ratio was deleted.
Fix for buttons being disabled when CT/PT ratios are not `1`.