### PR TITLE
Tab caching

### DIFF
--- a/Source/Applications/SystemCenter/AppDebug.config
+++ b/Source/Applications/SystemCenter/AppDebug.config
@@ -6,7 +6,7 @@
   <categorizedSettings>
     <systemSettings>
       <!-- *** MODIFY CONNECTION STRING AND DATA PROVIDER STRINGS BELOW *** -->
-      <add name="ConnectionString" value="Data Source=localhost; Initial Catalog=openXDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
+      <add name="ConnectionString" value="Data Source=vmhostsql; Initial Catalog=Demo_XDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
       <add name="DataProviderString" value="AssemblyName={System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089}; ConnectionType=System.Data.SqlClient.SqlConnection; AdapterType=System.Data.SqlClient.SqlDataAdapter" description="Configuration database ADO.NET data provider assembly type creation string used when ConfigurationType=Database" encrypted="false" />
       <!-- **************************************************************** -->
       <add name="NodeID" value="00000000-0000-0000-0000-000000000000" description="Unique Node ID" encrypted="false" />
@@ -41,7 +41,7 @@
     </systemSettings>
     <securityProvider>
       <add name="ApplicationName" value="SystemCenter" description="Name of the application being secured as defined in the backend security datastore." encrypted="false" />
-      <add name="ConnectionString" value="Data Source=localhost; Initial Catalog=openXDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
+      <add name="ConnectionString" value="Data Source=vmhostsql; Initial Catalog=Demo_XDA; Integrated Security=SSPI" description="Defines the connection to the openXDA database." encrypted="false" />
       <add name="ProviderType" value="GSF.Security.AdoSecurityProvider, GSF.Security" description="The type to be used for enforcing security." encrypted="false" />
       <add name="UserCacheTimeout" value="0" description="Defines the timeout, in whole minutes, for a user's provider cache. Any value less than 1 will cause cache reset every minute." encrypted="false" />
       <add name="IncludedResources" value="UpdateSettings,UpdateConfigFile=Special; Settings,Schedules,Help,Status,Version,Time,User,Health,List,Invoke,ListCommands,ListReports,GetReport=*; Processes,Start,ReloadCryptoCache,ReloadSettings,Reschedule,Unschedule,SaveSchedules,LoadSchedules,ResetHealthMonitor,Connect,Disconnect,Initialize,ReloadConfig,Authenticate,RefreshRoutes,TemporalSupport,LogEvent,GenerateReport,ReportingConfig=Administrator,Editor; *=Administrator" description="Semicolon delimited list of resources to be secured along with role names." encrypted="false" />

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ApplicationCategory.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ApplicationCategory.tsx
@@ -38,7 +38,7 @@ interface IProps { ID: number, Tab: tab }
 
 function ApplicationCategory(props: IProps) {
 
-    const [tab, setTab] = React.useState(getTab());
+    const [tab, setTabState] = React.useState(getTab());
     const [showDelete, setShowDelete] = React.useState<boolean>(false);
     const [loadDelete, setLoadDelete] = React.useState<boolean>(false);
     const acStatus = useAppSelector(ApplicationCategorySlice.Status) as Application.Types.Status;
@@ -64,6 +64,11 @@ function ApplicationCategory(props: IProps) {
             return 'appCatInfo';
     }
 
+    function setTab(tab: tab): void {
+        sessionStorage.setItem('ApplicationCategory.Tab', JSON.stringify(tab));
+        setTabState(tab);
+    }
+
     if (applicationCategory == null) return null;
     return (
         <div style={{ width: '100%', height: window.innerHeight - 63, maxHeight: window.innerHeight - 63, overflow: 'hidden', padding: 15 }}>
@@ -75,7 +80,7 @@ function ApplicationCategory(props: IProps) {
                     <button className="btn btn-danger pull-right" hidden={applicationCategory == null} onClick={() => { setShowDelete(true);} }>Delete Application Category</button>
                 </div>
             </div>
-            <TabSelector CurrentTab={tab} SetTab={(t: tab) => setTab(t)} Tabs={Tabs} />
+            <TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
 
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "appCatInfo" ? " active" : "fade")} id="appCatInfo">

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ApplicationCategory.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ApplicationCategory/ApplicationCategory.tsx
@@ -27,23 +27,20 @@ import { LoadingScreen, TabSelector, Warning } from '@gpa-gemstone/react-interac
 import { useAppDispatch, useAppSelector } from '../hooks';
 import { ApplicationCategorySlice } from '../Store/Store';
 import { Application } from '@gpa-gemstone/application-typings';
-import { Input } from '@gpa-gemstone/react-forms';
 import ApplicationCategoryInfo from './ApplicationCategoryInfo';
 import Applications from './Applications';
 
 declare var homePath: string;
-type tab = 'appCatInfo' | 'applications'
+type Tab = 'appCatInfo' | 'applications'
 
-interface IProps { ID: number, Tab: tab }
+interface IProps { ID: number, Tab: Tab }
 
 function ApplicationCategory(props: IProps) {
-
-    const [tab, setTabState] = React.useState(getTab());
+    const [tab, setTab] = React.useState(getTab());
     const [showDelete, setShowDelete] = React.useState<boolean>(false);
     const [loadDelete, setLoadDelete] = React.useState<boolean>(false);
     const acStatus = useAppSelector(ApplicationCategorySlice.Status) as Application.Types.Status;
     const applicationCategory = useAppSelector((state) => ApplicationCategorySlice.Datum(state, props.ID)) as ApplicationCategory;
-
     const dispatch = useAppDispatch();
 
     React.useEffect(() => {
@@ -51,12 +48,7 @@ function ApplicationCategory(props: IProps) {
             dispatch(ApplicationCategorySlice.Fetch());
     }, [acStatus]);
 
-    const Tabs: { Id: tab, Label: string }[] = [
-        { Id: "appCatInfo", Label: "Application Category Info" },
-        { Id: "applications", Label: "Applications" },
-    ];
-
-    function getTab(): tab {
+    function getTab(): Tab {
         if (props.Tab != undefined) return props.Tab;
         else if (sessionStorage.hasOwnProperty('ApplicationCategory.Tab'))
             return JSON.parse(sessionStorage.getItem('ApplicationCategory.Tab'));
@@ -64,12 +56,19 @@ function ApplicationCategory(props: IProps) {
             return 'appCatInfo';
     }
 
-    function setTab(tab: tab): void {
-        sessionStorage.setItem('ApplicationCategory.Tab', JSON.stringify(tab));
-        setTabState(tab);
-    }
+    React.useEffect(() => {
+        const saved = getTab();
+        if (saved !== tab)
+            sessionStorage.setItem('ApplicationCategory.Tab', JSON.stringify(tab));
+    }, [tab]);
+
+    const Tabs: { Id: Tab, Label: string }[] = [
+        { Id: "appCatInfo", Label: "Application Category Info" },
+        { Id: "applications", Label: "Applications" },
+    ];
 
     if (applicationCategory == null) return null;
+
     return (
         <div style={{ width: '100%', height: window.innerHeight - 63, maxHeight: window.innerHeight - 63, overflow: 'hidden', padding: 15 }}>
             <div className="row">
@@ -80,8 +79,9 @@ function ApplicationCategory(props: IProps) {
                     <button className="btn btn-danger pull-right" hidden={applicationCategory == null} onClick={() => { setShowDelete(true);} }>Delete Application Category</button>
                 </div>
             </div>
-            <TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
+            <hr />
 
+            <TabSelector CurrentTab={tab} SetTab={(t: Tab) => setTab(t)} Tabs={Tabs} />
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "appCatInfo" ? " active" : "fade")} id="appCatInfo">
                     <ApplicationCategoryInfo ApplicationCat={applicationCategory} stateSetter={(record) => dispatch(ApplicationCategorySlice.DBAction({verb: 'PATCH', record: record}))} />
@@ -97,6 +97,6 @@ function ApplicationCategory(props: IProps) {
             <LoadingScreen Show={loadDelete} />
             </div>
     )
-
 }
+
 export default ApplicationCategory;

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/Asset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/Asset.tsx
@@ -53,15 +53,25 @@ function Asset(props: IProps) {
 
     function getTab(): Tab {
         if (props.Tab != undefined) return props.Tab;
-        else if (sessionStorage.hasOwnProperty('Asset.Tab'))
-                return JSON.parse(sessionStorage.getItem('Asset.Tab'));
-        else return 'notes';
+
+        let key = 'Asset.Tab';
+        if (assetType == 'Line')
+            key = 'Line.Tab';
+
+        if (sessionStorage.hasOwnProperty(key))
+                return JSON.parse(sessionStorage.getItem(key));
+        return 'assetInfo';
     }
 
     React.useEffect(() => {
         const saved = getTab();
-        if (saved !== tab)
-            sessionStorage.setItem('Asset.Tab', JSON.stringify(tab)); 
+        if (saved !== tab) {
+            let key = 'Asset.Tab';
+            if (assetType == 'Line')
+                key = 'Line.Tab';
+            sessionStorage.setItem(key, JSON.stringify(tab)); 
+        }
+            
     }, [tab]);
 
     function getAsset() {
@@ -129,8 +139,8 @@ function Asset(props: IProps) {
         Tabs.push({ Id: "segments", Label: "Line Segments" });
         Tabs.push({ Id: "sourceImpedances", Label: "Source Impedances" });
     }
-    if (assetType == 'Breaker' || assetType == 'CapacitorBank' || assetType == 'Line' || assetType == 'Transformer' || assetType == 'Bus')
-        Tabs.push({ Id: "extDB", Label: "External DB" });
+    //if (assetType == 'Breaker' || assetType == 'CapacitorBank' || assetType == 'Line' || assetType == 'Transformer' || assetType == 'Bus')
+    //    Tabs.push({ Id: "extDB", Label: "External DB" });
     
     return (
         <div style={{ width: '100%', height: window.innerHeight - 63, maxHeight: window.innerHeight - 63, overflow: 'hidden', padding: 15 }}>
@@ -167,9 +177,9 @@ function Asset(props: IProps) {
                 <div className={"tab-pane " + (tab == "connections" ? " active" : "fade")} id="connections">
                     <AssetConnectionWindow Asset={asset} />
                 </div>
-                <div className={"tab-pane " + (tab == "extDB" ? " active" : "fade")} id="extDB">
-                    <ExternalDBUpdate ID={asset.ID} Type={(assetType == null) ? "Asset" : assetType} Tab={tab} />
-                </div>
+                {/*<div className={"tab-pane " + (tab == "extDB" ? " active" : "fade")} id="extDB">
+                //    <ExternalDBUpdate ID={asset.ID} Type={(assetType == null) ? "Asset" : assetType} Tab={tab} />
+                //</div>*/}
                 <div className={"tab-pane " + (tab == "sourceImpedances" ? " active" : "fade")} id="sourceImpedances">
                     <SourceImpedanceWindow ID={asset.ID} />
                 </div>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/Asset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/Asset.tsx
@@ -39,27 +39,30 @@ import { LoadingScreen, TabSelector, Warning } from '@gpa-gemstone/react-interac
 import SourceImpedanceWindow from '../AssetAttribute/SourceImpedanceWindow';
 
 declare var homePath: string;
-declare type Tab = 'notes' | 'assetInfo' | 'substations' | 'meters' | 'connections' | 'additionalFields' | 'extDB' | 'Segments' | 'SourceImpedances'
+declare type Tab = 'notes' | 'assetInfo' | 'substations' | 'meters' | 'connections' | 'additionalFields' | 'extDB' | 'segments' | 'sourceImpedances' | 'channels'
 
-function Asset(props: { AssetID: number }) {
+interface IProps { AssetID: number, Tab: Tab }
+
+function Asset(props: IProps) {
     let history = useHistory();
     const [asset, setAsset] = React.useState<OpenXDA.Types.Asset>(null);
-    const [tab, setTabState] = React.useState<string>(getTab());
+    const [tab, setTab] = React.useState(getTab());
     const [assetType, setAssetType] = React.useState<OpenXDA.Types.AssetTypeName>(null);
     const [showDelete, setShowDelete] = React.useState<boolean>(false);
     const [loadDelete, setLoadDelete] = React.useState<boolean>(false);
 
     function getTab(): Tab {
-        if (sessionStorage.hasOwnProperty('Asset.Tab'))
-            return JSON.parse(sessionStorage.getItem('Asset.Tab'));
-        else
-            return 'notes';
+        if (props.Tab != undefined) return props.Tab;
+        else if (sessionStorage.hasOwnProperty('Asset.Tab'))
+                return JSON.parse(sessionStorage.getItem('Asset.Tab'));
+        else return 'notes';
     }
 
-    function setTab(tab: Tab): void {
-        sessionStorage.setItem('Asset.Tab', JSON.stringify(tab));
-        setTabState(tab);
-    }
+    React.useEffect(() => {
+        const saved = getTab();
+        if (saved !== tab)
+            sessionStorage.setItem('Asset.Tab', JSON.stringify(tab)); 
+    }, [tab]);
 
     function getAsset() {
         return    $.ajax({
@@ -70,7 +73,6 @@ function Asset(props: { AssetID: number }) {
             cache: false,
             async: true
        })
-
     }
 
     function getAssetType(asset: OpenXDA.Types.Asset): void {
@@ -91,32 +93,24 @@ function Asset(props: { AssetID: number }) {
             cache: true,
             async: true
         });
-
         handle.done((msg) => {
             sessionStorage.clear();
             history.push({ pathname: homePath + 'index.cshtml', search: '?name=Assets' });
         });
-
         handle.then((d) => setLoadDelete(false))
-
         return handle;
     }
 
     React.useEffect(() => {
         if (props.AssetID == undefined) return () => { };
         let handle = getAsset();
-
         handle.done((data: OpenXDA.Types.Asset) => {
             setAsset(data)
             getAssetType(data)
         });
-
         return () => {
             if (handle.abort != undefined) handle.abort();
-
         }
-
-        
     }, [props.AssetID]);
 
     if (asset == null) return null;
@@ -132,8 +126,8 @@ function Asset(props: { AssetID: number }) {
        ];
 
     if (assetType == 'Line') {
-        Tabs.push({ Id: "Segments", Label: "Line Segments" });
-        Tabs.push({ Id: "SourceImpedances", Label: "Source Impedances" });
+        Tabs.push({ Id: "segments", Label: "Line Segments" });
+        Tabs.push({ Id: "sourceImpedances", Label: "Source Impedances" });
     }
     if (assetType == 'Breaker' || assetType == 'CapacitorBank' || assetType == 'Line' || assetType == 'Transformer' || assetType == 'Bus')
         Tabs.push({ Id: "extDB", Label: "External DB" });
@@ -148,11 +142,9 @@ function Asset(props: { AssetID: number }) {
                     <button className="btn btn-danger pull-right" hidden={asset == null} onClick={() => setShowDelete(true)}>Delete Asset</button>
                 </div>
             </div>
-
-
             <hr />
-            <TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
-             
+
+            <TabSelector CurrentTab={tab} SetTab={(t: Tab) => setTab(t)} Tabs={Tabs} />
             <div className="tab-content" style={{maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "notes" ? " active" : "fade")} id="notes">
                     <NoteWindow ID={asset.ID} Type='Asset' />
@@ -178,13 +170,14 @@ function Asset(props: { AssetID: number }) {
                 <div className={"tab-pane " + (tab == "extDB" ? " active" : "fade")} id="extDB">
                     <ExternalDBUpdate ID={asset.ID} Type={(assetType == null) ? "Asset" : assetType} Tab={tab} />
                 </div>
-                <div className={"tab-pane " + (tab == "SourceImpedances" ? " active" : "fade")} id="SourceImpedances">
+                <div className={"tab-pane " + (tab == "sourceImpedances" ? " active" : "fade")} id="sourceImpedances">
                     <SourceImpedanceWindow ID={asset.ID} />
                 </div>
-                <div className={"tab-pane " + (tab == "Segments" ? " active" : "fade")} id="Segments">
+                <div className={"tab-pane " + (tab == "segments" ? " active" : "fade")} id="segments">
                     <LineSegmentWindow ID={asset.ID}/>
                 </div>
             </div>
+
             <Warning Message={'This will permanently delete this Asset and cannot be undone.'} Show={showDelete} Title={'Delete ' + (asset?.AssetName ?? 'Asset')} CallBack={(conf) => { if (conf) deleteAsset(); setShowDelete(false); }} />
             <LoadingScreen Show={loadDelete} />
         </div>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceIssuesPage/DeviceIssuesPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceIssuesPage/DeviceIssuesPage.tsx
@@ -31,10 +31,13 @@ import OpenXDAIssuesPage from './OpenXDAIssuesPage';
 import DownloadedFilesPage from './DownloadedFilesPage';
 import DataQualityIssuesPage from './DataQualityIssuesPage';
 
-type DeviceIssuesPageTab = 'notes' | 'openmic' | 'mimd' | 'xda' | 'files' | 'dq'
-function DeviceIssuesPage(props: {MeterID: number, OpenMICAcronym: string, Tab? : DeviceIssuesPageTab}) {
+declare type Tab = 'notes' | 'openmic' | 'mimd' | 'xda' | 'files' | 'dq'
+
+interface IProps { MeterID: number, OpenMICAcronym: string, Tab: Tab }
+
+function DeviceIssuesPage(props: IProps) {
     const [meter, setMeter] = React.useState<OpenXDA.Types.Meter>(null);
-    const [tab, setTab] = React.useState<DeviceIssuesPageTab>(props?.Tab ?? 'notes');
+    const [tab, setTab] = React.useState(getTab());
 
     React.useEffect(() => {
         let handle = getMeter();
@@ -57,17 +60,29 @@ function DeviceIssuesPage(props: {MeterID: number, OpenMICAcronym: string, Tab? 
         })
     }
 
+    function getTab(): Tab {
+        if (props.Tab != undefined) return props.Tab;
+        else if (sessionStorage.hasOwnProperty('DeviceIssuesPage.Tab'))
+            return JSON.parse(sessionStorage.getItem('DeviceIssuesPage.Tab'));
+        else
+            return 'notes';
+    }
+
+    React.useEffect(() => {
+        const saved = getTab();
+        if (saved !== tab)
+            sessionStorage.setItem('DeviceIssuesPage.Tab', JSON.stringify(tab));
+    }, [tab]);
 
     if (meter == null) return null;
 
-    const Tabs: {Id: DeviceIssuesPageTab, Label: string }[] = [
+    const Tabs = [
         { Id: "notes", Label: "Notes" },
         { Id: "openmic", Label: "openMIC" },
         { Id: "mimd", Label: "miMD" },
         { Id: "xda", Label: "openXDA" },
         { Id: "dq", Label: "Data Quality" },
         { Id: "files", Label: "Last 50 Downloaded Files" },
-
     ];
 
     return (
@@ -78,8 +93,8 @@ function DeviceIssuesPage(props: {MeterID: number, OpenMICAcronym: string, Tab? 
                 </div>
             </div>
             <hr />
-            <TabSelector CurrentTab={tab} SetTab={(t:DeviceIssuesPageTab) => setTab(t)} Tabs={Tabs} />
 
+            <TabSelector CurrentTab={tab} SetTab={(t: Tab) => setTab(t)} Tabs={Tabs} />
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 215, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "notes" ? " active" : "fade")} id="notes" style={{ maxHeight: window.innerHeight - 215 }}>
                     <NoteWindow ID={props.MeterID} Type='Meter' />
@@ -99,11 +114,8 @@ function DeviceIssuesPage(props: {MeterID: number, OpenMICAcronym: string, Tab? 
                 <div className={"tab-pane " + (tab == "files" ? " active" : "fade")} id="files" style={{ maxHeight: window.innerHeight - 215 }}>
                     <DownloadedFilesPage Meter={meter} />
                 </div>
-
             </div>
         </div>
-       
-
     )
 }
 

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/Location.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/Location.tsx
@@ -43,17 +43,7 @@ function Location(props: IProps) {
     const [showDelete, setShowDelete] = React.useState<boolean>(false);
     const [loadDelete, setLoadDelete] = React.useState<boolean>(false);
     const [location, setLocation] = React.useState<OpenXDA.Types.Location>(null);
-    const [tab, setTab] = React.useState<tab>(getTab());
-
-    React.useEffect(() => {
-        sessionStorage.setItem('Location.Tab', JSON.stringify(tab));
-
-    }, [tab]);
-
-    React.useEffect(() => {
-        setTab(getTab());
-        return () => { sessionStorage.clear(); }
-    }, []);
+    const [tab, setTabState] = React.useState<tab>(getTab());
 
     React.useEffect(() => {
         let handle = getLocation();
@@ -68,6 +58,11 @@ function Location(props: IProps) {
             return JSON.parse(sessionStorage.getItem('Location.Tab'));
         else
             return 'notes';
+    }
+
+    function setTab(tab: tab): void {
+        sessionStorage.setItem('Location.Tab', JSON.stringify(tab));
+        setTabState(tab);
     }
 
     function getLocation(): JQuery.jqXHR<OpenXDA.Types.Location> {
@@ -128,7 +123,7 @@ function Location(props: IProps) {
             </div>
 
             <hr />
-            <TabSelector CurrentTab={tab} SetTab={(t: tab) => setTab(t)} Tabs={Tabs} />
+            <TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
 
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 215, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "notes" ? " active" : "fade")} id="notes">

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/Location.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/Location.tsx
@@ -35,24 +35,23 @@ import LocationImagesWindow from './LocationImages';
 import LocationDrawingsWindow from './LocationDrawings';
 
 declare var homePath: string;
-type tab = 'notes' | 'locationInfo' | 'additionalFields' | 'meters' | 'assets' | 'extDB' | 'images' | 'drawings'
+type Tab = 'notes' | 'locationInfo' | 'additionalFields' | 'meters' | 'assets' | 'extDB' | 'images' | 'drawings'
 
-interface IProps { LocationID: number, Tab: tab }
+interface IProps { LocationID: number, Tab: Tab }
 
 function Location(props: IProps) {
     const [showDelete, setShowDelete] = React.useState<boolean>(false);
     const [loadDelete, setLoadDelete] = React.useState<boolean>(false);
     const [location, setLocation] = React.useState<OpenXDA.Types.Location>(null);
-    const [tab, setTabState] = React.useState<tab>(getTab());
+    const [tab, setTab] = React.useState(getTab());
 
     React.useEffect(() => {
         let handle = getLocation();
         handle.then((data: OpenXDA.Types.Location) => setLocation(data));
         return () => { if (handle != null && handle.abort != null) handle.abort(); }
-
     }, [props.LocationID]);
 
-    function getTab(): tab {
+    function getTab(): Tab {
         if (props.Tab != undefined) return props.Tab;
         else if (sessionStorage.hasOwnProperty('Location.Tab'))
             return JSON.parse(sessionStorage.getItem('Location.Tab'));
@@ -60,10 +59,11 @@ function Location(props: IProps) {
             return 'notes';
     }
 
-    function setTab(tab: tab): void {
-        sessionStorage.setItem('Location.Tab', JSON.stringify(tab));
-        setTabState(tab);
-    }
+    React.useEffect(() => {
+        const saved = getTab();
+        if (saved !== tab)
+            sessionStorage.setItem('Location.Tab', JSON.stringify(tab));
+    }, [tab]);
 
     function getLocation(): JQuery.jqXHR<OpenXDA.Types.Location> {
         if(props.LocationID == undefined) return null;
@@ -87,19 +87,16 @@ function Location(props: IProps) {
             cache: true,
             async: true
         });
-
         handle.done(() => {
             window.location.href = homePath + 'index.cshtml?name=Locations'
         })
-
         handle.then((d) => setLoadDelete(false))
-
         return handle;
     }
      
     if (location == null) return null;
 
-    const Tabs: { Id: tab, Label: string }[] = [
+    const Tabs = [
         { Id: "notes", Label: "Notes" },
         { Id: "locationInfo", Label: "Substation Info" },
         { Id: "additionalFields", Label: "Additional Fields" },
@@ -109,7 +106,6 @@ function Location(props: IProps) {
         { Id: "images", Label: "Images" },
         { Id: "drawings", Label: "Drawings" },
     ];
-
 
     return (
         <div style={{ width: '100%', height: window.innerHeight - 63, maxHeight: window.innerHeight - 63, overflow: 'hidden', padding: 15 }}>
@@ -121,10 +117,9 @@ function Location(props: IProps) {
                     <button className="btn btn-danger pull-right" hidden={location == null} onClick={() => setShowDelete(true)}>Delete Substation</button>
                 </div>
             </div>
-
             <hr />
-            <TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
 
+            <TabSelector CurrentTab={tab} SetTab={(t: Tab) => setTab(t)} Tabs={Tabs} />
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 215, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "notes" ? " active" : "fade")} id="notes">
                     <NoteWindow ID={props.LocationID} Type='Location' />
@@ -150,13 +145,12 @@ function Location(props: IProps) {
                 <div className={"tab-pane " + (tab == "drawings" ? " active" : "fade")} id="drawings">
                     <LocationDrawingsWindow Location={location} />
                 </div>
-
             </div>
+
             <Warning Message={'This will permanently delete this Substation and cannot be undone.'} Show={showDelete} Title={'Delete ' + (location?.Name ?? 'Substation')} CallBack={(conf) => { if (conf) deleteLocation(); setShowDelete(false); }} />
             <LoadingScreen Show={loadDelete} />
         </div>
     )
 }
   
-
 export default Location;

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/Meter.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/Meter.tsx
@@ -44,13 +44,13 @@ import DataDeleteWindow from './Advanced/MeterDataDelete';
 import { CreateGuid } from '@gpa-gemstone/helper-functions';
  
 declare var homePath: string;
-declare type tab = 'notes' | 'meterInfo' | 'additionalFields' | 'substation' | 'assets' | 'eventChannels' | 'trendChannels' | 'channelScaling' | 'configurationHistory' | 'extDB' | 'maintenance' | 'dataRescue' | 'dataMerge' | 'dataDelete'
+declare type Tab = 'notes' | 'meterInfo' | 'additionalFields' | 'substation' | 'assets' | 'eventChannels' | 'trendChannels' | 'channelScaling' | 'configurationHistory' | 'extDB' | 'maintenance' | 'dataRescue' | 'dataMerge' | 'dataDelete'
 
-interface IProps { MeterID: number, Tab: tab }
+interface IProps { MeterID: number, Tab: Tab }
 
 function Meter(props: IProps) {
     const [meter, setMeter] = React.useState<OpenXDA.Types.Meter>(null);
-    const [Tab, setTabState] = React.useState<string>(getTab());
+    const [tab, setTab] = React.useState(getTab());
     const [showAdvanced, setShowAdvanced] = React.useState<boolean>(false);
     const [showDelete, setShowDelete] = React.useState<boolean>(false);
     const [loadDelete, setLoadDelete] = React.useState<boolean>(false);
@@ -62,20 +62,21 @@ function Meter(props: IProps) {
         let handle = getMeter();
         handle.then((data: OpenXDA.Types.Meter) => setMeter(data));
         return () => { if (handle != null && handle.abort != null) handle.abort(); }
-
     }, [props.MeterID]);
 
-    function getTab(): string {
-        if (sessionStorage.hasOwnProperty('Meter.Tab'))
+    function getTab(): Tab {
+        if (props.Tab != undefined) return props.Tab;
+        else if (sessionStorage.hasOwnProperty('Meter.Tab'))
             return JSON.parse(sessionStorage.getItem('Meter.Tab'));
         else
             return 'notes';
     }
 
-    function setTab(tab: tab): void {
-        sessionStorage.setItem('Meter.Tab', JSON.stringify(tab));
-        setTabState(tab);
-    }
+    React.useEffect(() => {
+        const saved = getTab();
+        if (saved !== tab)
+            sessionStorage.setItem('Meter.Tab', JSON.stringify(tab));
+    }, [tab]);
 
     function getMeter(): JQuery.jqXHR<OpenXDA.Types.Meter> {
         if (props.MeterID == undefined) return null;
@@ -90,9 +91,7 @@ function Meter(props: IProps) {
     }
 
     function deleteMeter(): JQuery.jqXHR {
-
         setLoadDelete(true);
-
         let handle = $.ajax({
             type: "DELETE",
             url: `${homePath}api/OpenXDA/Meter/Delete`,
@@ -102,13 +101,10 @@ function Meter(props: IProps) {
             cache: true,
             async: true
         });
-
         handle.done(() => {
             window.location.href = homePath + 'index.cshtml?name=Meters'
         })
-
         handle.then((d) => setLoadDelete(false))
-
         return handle;
     }
 
@@ -116,10 +112,8 @@ function Meter(props: IProps) {
         // Create a new key to reset state whenever
         // the user navigates to data rescue
         const guid = CreateGuid();
-
         const newWindow = () =>
             <DataRescueWindow key={guid} Meter={meter} />;
-
         setShowAdvanced(false);
         setTab("dataRescue");
         setDataRescueWindow(newWindow());
@@ -129,14 +123,11 @@ function Meter(props: IProps) {
         // Create a new key to reset state whenever
         // the user navigates to data merge
         const guid = CreateGuid();
-
         const returnToMeters = () => {
             window.location.href = homePath + 'index.cshtml?name=Meters';
         };
-
         const newWindow = () =>
             <DataMergeWindow key={guid} Meter={meter} OnMerge={returnToMeters} />;
-
         setShowAdvanced(false);
         setTab("dataMerge");
         setDataMergeWindow(newWindow());
@@ -146,14 +137,11 @@ function Meter(props: IProps) {
         // Create a new key to reset state whenever
         // the user navigates to data delete
         const guid = CreateGuid();
-
         const returnToMeters = () => {
             window.location.href = homePath + 'index.cshtml?name=Meters';
         };
-
         const newWindow = () =>
             <DataDeleteWindow key={guid} Meter={meter} OnDelete={returnToMeters} />;
-
         setShowAdvanced(false);
         setTab("dataDelete");
         setDataDeleteWindow(newWindow());
@@ -185,65 +173,64 @@ function Meter(props: IProps) {
                     <button className="btn btn-light pull-right" onClick={() => setShowAdvanced(true)}>Advanced</button>
                 </div>
             </div>
-
             <hr />
-            <TabSelector CurrentTab={Tab} SetTab={setTab} Tabs={Tabs} />
 
+            <TabSelector CurrentTab={tab} SetTab={(t: Tab) => setTab(t)} Tabs={Tabs} />
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 215, overflow: 'hidden' }}>
-                <div className={"tab-pane " + (Tab == "notes" ? " active" : "fade")} id="notes" style={{ maxHeight: window.innerHeight - 215 }}>
+                <div className={"tab-pane " + (tab == "notes" ? " active" : "fade")} id="notes" style={{ maxHeight: window.innerHeight - 215 }}>
                     <NoteWindow ID={props.MeterID} Type='Meter' />
                 </div>
-                <div className={"tab-pane " + (Tab == "meterInfo" ? " active" : "fade")} id="meterInfo" style={{ maxHeight: window.innerHeight - 215 }}>
+                <div className={"tab-pane " + (tab == "meterInfo" ? " active" : "fade")} id="meterInfo" style={{ maxHeight: window.innerHeight - 215 }}>
                     <MeterInfoWindow Meter={meter} StateSetter={(meter: OpenXDA.Types.Meter) => setMeter(meter)} />
                 </div>
-                <div className={"tab-pane " + (Tab == "additionalFields" ? " active" : "fade")} id="additionalFields" style={{ maxHeight: window.innerHeight - 215 }}>
-                    <AdditionalFieldsWindow ID={props.MeterID} Type='Meter' Tab={Tab} />
+                <div className={"tab-pane " + (tab == "additionalFields" ? " active" : "fade")} id="additionalFields" style={{ maxHeight: window.innerHeight - 215 }}>
+                    <AdditionalFieldsWindow ID={props.MeterID} Type='Meter' Tab={tab} />
                 </div>
-                <div className={"tab-pane " + (Tab == "substation" ? " active" : "fade")} id="substation" style={{ maxHeight: window.innerHeight - 215 }}>
+                <div className={"tab-pane " + (tab == "substation" ? " active" : "fade")} id="substation" style={{ maxHeight: window.innerHeight - 215 }}>
                     <MeterLocationWindow Meter={meter} StateSetter={(meter: OpenXDA.Types.Meter) => setMeter(meter)} />
                 </div>
-                <div className={"tab-pane " + (Tab == "eventChannels" ? " active" : "fade")} id="eventChannels">
-                    <MeterEventChannelWindow Meter={meter} IsVisible={Tab === "eventChannels"} />
+                <div className={"tab-pane " + (tab == "eventChannels" ? " active" : "fade")} id="eventChannels">
+                    <MeterEventChannelWindow Meter={meter} IsVisible={tab === "eventChannels"} />
                 </div>
-                <div className={"tab-pane " + (Tab == "trendChannels" ? " active" : "fade")} id="trendChannels">
-                    <MeterTrendChannelWindow Meter={meter} IsVisible={Tab === "trendChannels"} />
+                <div className={"tab-pane " + (tab == "trendChannels" ? " active" : "fade")} id="trendChannels">
+                    <MeterTrendChannelWindow Meter={meter} IsVisible={tab === "trendChannels"} />
                 </div>
-                <div className={"tab-pane " + (Tab == "channelScaling" ? " active" : "fade")} id="channelScaling">
-                    <ChannelScalingWindow Meter={meter} IsVisible={Tab === "channelScaling"} />
+                <div className={"tab-pane " + (tab == "channelScaling" ? " active" : "fade")} id="channelScaling">
+                    <ChannelScalingWindow Meter={meter} IsVisible={tab === "channelScaling"} />
                 </div>
-                <div className={"tab-pane " + (Tab == "assets" ? " active" : "fade")} id="assets">
+                <div className={"tab-pane " + (tab == "assets" ? " active" : "fade")} id="assets">
                     <MeterAssetWindow Meter={meter} />
                 </div>
-                <div className={"tab-pane " + (Tab == "configurationHistory" ? " active" : "fade")} id="configurationHistory">
+                <div className={"tab-pane " + (tab == "configurationHistory" ? " active" : "fade")} id="configurationHistory">
                     <MeterConfigurationHistoryWindow Meter={meter} />
                 </div>
-                <div className={"tab-pane " + (Tab == "extDB" ? " active" : "fade")} id="extDB">
-                    <ExternalDBUpdate ID={props.MeterID} Type='Meter' Tab={Tab} />
+                <div className={"tab-pane " + (tab == "extDB" ? " active" : "fade")} id="extDB">
+                    <ExternalDBUpdate ID={props.MeterID} Type='Meter' Tab={tab} />
                 </div>
-                <div className={"tab-pane " + (Tab == "dataRescue" ? " active" : "fade")} id="dataRescue">
+                <div className={"tab-pane " + (tab == "dataRescue" ? " active" : "fade")} id="dataRescue">
                     {dataRescueWindow}
                 </div>
-                <div className={"tab-pane " + (Tab == "dataMerge" ? " active" : "fade")} id="dataMerge">
+                <div className={"tab-pane " + (tab == "dataMerge" ? " active" : "fade")} id="dataMerge">
                     {dataMergeWindow}
                 </div>
-                <div className={"tab-pane " + (Tab == "dataDelete" ? " active" : "fade")} id="dataDelete">
+                <div className={"tab-pane " + (tab == "dataDelete" ? " active" : "fade")} id="dataDelete">
                     {dataDeleteWindow}
                 </div>
-                <div className={"tab-pane " + (Tab == "maintenance" ? " active" : "fade")} id="maintenance">
+                <div className={"tab-pane " + (tab == "maintenance" ? " active" : "fade")} id="maintenance">
                     <MeterMaintenanceWindow Meter={meter} />
                 </div>
             </div>
+
             <Modal Title={'Advanced Options'} Show={showAdvanced} CallBack={() => setShowAdvanced(false)} ShowCancel={false} ConfirmText={'Close'}>
                 <button className="btn btn-dark btn-block" onClick={showDataRescueWindow}>Data Rescue</button>
                 <button className="btn btn-dark btn-block" onClick={showDataMergeWindow}>Merge Data</button>
                 <button className="btn btn-danger btn-block" onClick={showDataDeleteWindow}>Delete Data</button>
             </Modal>
+
             <Warning Message={'This will permanently delete this Meter and cannot be undone.'} Show={showDelete} Title={'Delete ' + (meter?.Name ?? 'Meter')} CallBack={(conf) => { if (conf) deleteMeter(); setShowDelete(false); }} />
             <LoadingScreen Show={loadDelete} />
         </div>
-       
-
-            )
+    )
 }
 
 export default Meter;

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/Meter.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/Meter.tsx
@@ -44,29 +44,19 @@ import DataDeleteWindow from './Advanced/MeterDataDelete';
 import { CreateGuid } from '@gpa-gemstone/helper-functions';
  
 declare var homePath: string;
+declare type tab = 'notes' | 'meterInfo' | 'additionalFields' | 'substation' | 'assets' | 'eventChannels' | 'trendChannels' | 'channelScaling' | 'configurationHistory' | 'extDB' | 'maintenance' | 'dataRescue' | 'dataMerge' | 'dataDelete'
 
-interface IProps { MeterID: number }
+interface IProps { MeterID: number, Tab: tab }
 
 function Meter(props: IProps) {
     const [meter, setMeter] = React.useState<OpenXDA.Types.Meter>(null);
-    const [Tab, setTab] = React.useState<string>(null);
+    const [Tab, setTabState] = React.useState<string>(getTab());
     const [showAdvanced, setShowAdvanced] = React.useState<boolean>(false);
     const [showDelete, setShowDelete] = React.useState<boolean>(false);
     const [loadDelete, setLoadDelete] = React.useState<boolean>(false);
     const [dataRescueWindow, setDataRescueWindow] = React.useState<React.ReactElement>();
     const [dataMergeWindow, setDataMergeWindow] = React.useState<React.ReactElement>();
     const [dataDeleteWindow, setDataDeleteWindow] = React.useState<React.ReactElement>();
-
-    React.useEffect(() => {
-        setTab(getTab());
-        return () => { sessionStorage.clear(); }
-    }, []);
-
-    React.useEffect(() => {
-        if (Tab == null)
-            return;
-        sessionStorage.setItem('Meter.Tab', JSON.stringify(Tab));
-    }, [Tab]);
 
     React.useEffect(() => {
         let handle = getMeter();
@@ -80,6 +70,11 @@ function Meter(props: IProps) {
             return JSON.parse(sessionStorage.getItem('Meter.Tab'));
         else
             return 'notes';
+    }
+
+    function setTab(tab: tab): void {
+        sessionStorage.setItem('Meter.Tab', JSON.stringify(tab));
+        setTabState(tab);
     }
 
     function getMeter(): JQuery.jqXHR<OpenXDA.Types.Meter> {

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SystemCenter.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SystemCenter.tsx
@@ -298,9 +298,9 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "ExternalDB")
                                     return <ExternalDB ID={parseInt(qs.ID as string)} />
                                 else if (qs['?name'] == "User")
-                                    return <User UserID={qs.UserAccountID as string} />
+                                    return <User UserID={qs.UserAccountID as string} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "Group")
-                                    return <UserGroup GroupID={qs.GroupID as string} />
+                                    return <UserGroup GroupID={qs.GroupID as string} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "ByApplicationCategory")
                                     return <ByApplicationCategory Roles={roles} />
                                 else if (qs['?name'] == "DBCleanup")
@@ -310,7 +310,7 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "UserStatistics")
                                     return <UserStatistics Roles={roles} />
                                 else if (qs['?name'] == "Meter")
-                                    return <Meter MeterID={parseInt(qs.MeterID as string)} />
+                                    return <Meter MeterID={parseInt(qs.MeterID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "Location")
                                     return <Location LocationID={parseInt(qs.LocationID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "Asset")
@@ -326,7 +326,7 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "NewMeterWizard")
                                     return <NewMeterWizard IsEngineer={roles.indexOf('Administrator') >= 0 || roles.indexOf('Transmission SME') >= 0} />
                                 else if (qs['?name'] == "ValueListGroup")
-                                    return <ValueListGroup GroupID={parseInt(qs.GroupID as string)} />
+                                    return <ValueListGroup GroupID={parseInt(qs.GroupID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "ChannelGroup")
                                     return <ChannelGroup GroupID={parseInt(qs.GroupID as string)} />
                                 else if (qs['?name'] == "Settings")

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SystemCenter.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SystemCenter.tsx
@@ -353,7 +353,7 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "Groups")
                                     return <BySecuritytGroup Roles={roles} />
                                 else if (qs['?name'] == "MATLABAnalytic")
-                                    return <MATLABAnalytic AnalyticID={parseInt(qs.AnalyticID as string)} />
+                                    return <MATLABAnalytic AnalyticID={parseInt(qs.AnalyticID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "DownloadedFiles")
                                     return <DownloadedFiles MeterID={parseInt(qs.MeterID as string)} MeterName={qs.MeterName as string } />
                                 else if (qs['?name'] == "DeviceContacts")

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SystemCenter.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/SystemCenter.tsx
@@ -292,7 +292,7 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "RemoteXDAInstanceMain")
                                     return <RemoteXDAInstanceMain Roles={roles} />
                                 else if (qs['?name'] == "RemoteXDAInstance")
-                                    return <RemoteXDAInstance ID={parseInt(qs.ID as string)} Roles={roles} />
+                                    return <RemoteXDAInstance ID={parseInt(qs.ID as string)} Roles={roles} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "ByExternalDB")
                                     return <ByExternalDB Roles={roles} />
                                 else if (qs['?name'] == "ExternalDB")
@@ -314,11 +314,11 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "Location")
                                     return <Location LocationID={parseInt(qs.LocationID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "Asset")
-                                    return <Asset AssetID={parseInt(qs.AssetID as string)} />
+                                    return <Asset AssetID={parseInt(qs.AssetID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "AssetGroup")
-                                    return <AssetGroup AssetGroupID={parseInt(qs.AssetGroupID as string)} />
+                                    return <AssetGroup AssetGroupID={parseInt(qs.AssetGroupID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "Customer")
-                                    return <Customer CustomerID={parseInt(qs.CustomerID as string)} />
+                                    return <Customer CustomerID={parseInt(qs.CustomerID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "PQViewSites")
                                     return <iframe style={{ width: '100%', height: '100%' }} src={homePath + 'PQViewDataLoader.cshtml'}></iframe>
                                 else if (qs['?name'] == "PQViewCustomers")
@@ -328,7 +328,7 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "ValueListGroup")
                                     return <ValueListGroup GroupID={parseInt(qs.GroupID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "ChannelGroup")
-                                    return <ChannelGroup GroupID={parseInt(qs.GroupID as string)} />
+                                    return <ChannelGroup GroupID={parseInt(qs.GroupID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "Settings")
                                     return <BySettings Roles={roles} System={qs.System as 'SystemCenter' | 'OpenXDA' | 'MiMD'} />
                                 else if (qs['?name'] == "DataOperations")
@@ -347,7 +347,7 @@ const SystemCenter: React.FunctionComponent = (props: {}) => {
                                 else if (qs['?name'] == "SEBrowserTabs")
                                     return <BySEBrowserCategory Roles={roles} />
                                 else if (qs['?name'] == "SEBrowserTab")
-                                    return <SEBrowserCategory TabID={parseInt(qs.TabID as string)} />
+                                    return <SEBrowserCategory TabID={parseInt(qs.TabID as string)} Tab={qs.Tab as any} />
                                 else if (qs['?name'] == "MagDurCurves")
                                     return <ByMagDurCurve Roles={roles} />
                                 else if (qs['?name'] == "Groups")

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/User.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/User/User.tsx
@@ -32,8 +32,11 @@ import { CheckBox } from '@gpa-gemstone/react-forms';
 import { UserAccountSlice } from '../../Store/Store';
 import { useHistory } from "react-router-dom";
 
+declare type tab = 'userInfo' | 'permissions' | 'additionalFields'
+
 interface IProps {
-	UserID: string
+	UserID: string,
+	Tab: tab
 }
 
 function User(props: IProps) {
@@ -43,10 +46,22 @@ function User(props: IProps) {
 	const user = useAppSelector((state) => UserAccountSlice.Datum(state, props.UserID));
 	const status: Application.Types.Status = useAppSelector(UserAccountSlice.Status);
 
-	const [tab, setTab] = React.useState<string>('userInfo')
+	const [tab, setTabState] = React.useState<string>(getTab())
 
 	const [showWarning, setShowWarning] = React.useState<boolean>(false);
 
+	function getTab(): tab {
+		if (props.Tab != undefined) return props.Tab;
+		else if (sessionStorage.hasOwnProperty('User.Tab'))
+			return JSON.parse(sessionStorage.getItem('User.Tab'));
+		else
+			return 'userInfo';
+	}
+
+	function setTab(tab: tab): void {
+		sessionStorage.setItem('User.Tab', JSON.stringify(tab));
+		setTabState(tab);
+	}
 
 	React.useEffect(() => {
 		if (status === 'unintiated' || status === 'changed')
@@ -76,7 +91,7 @@ function User(props: IProps) {
 			</div>
 			<LoadingScreen Show={status === 'loading'} />
 			<hr />
-			<TabSelector CurrentTab={tab} SetTab={(t) => setTab(t)} Tabs={Tabs} />
+			<TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
 			<div className="tab-content" style={{ maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
 				<div className={"tab-pane " + (tab === "userInfo" ? " active" : "fade")}>
 					<UserInfo AccountId={props.UserID} />

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/UserGroup/UserGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/UserGroup/UserGroup.tsx
@@ -34,8 +34,11 @@ import GroupInfo from './Info';
 import GroupUser from './GroupUsers';
 import GroupPermission from './Permissions';
 
+declare type tab = 'info' | 'users' | 'roles'
+
 interface IProps {
-	GroupID: string
+	GroupID: string,
+	Tab: tab
 }
 
 function UserGroup(props: IProps) {
@@ -45,9 +48,22 @@ function UserGroup(props: IProps) {
 	const group: ISecurityGroup = useAppSelector((state) => SecurityGroupSlice.Datum(state, props.GroupID) as ISecurityGroup);
 	const status = useAppSelector(SecurityGroupSlice.Status);
 
-	const [tab, setTab] = React.useState<string>('info')
+	const [tab, setTabState] = React.useState<string>(getTab())
 
 	const [showWarning, setShowWarning] = React.useState<boolean>(false);
+
+	function getTab(): tab {
+		if (props.Tab != undefined) return props.Tab;
+		else if (sessionStorage.hasOwnProperty('UserGroup.Tab'))
+			return JSON.parse(sessionStorage.getItem('UserGroup.Tab'));
+		else
+			return 'info';
+	}
+
+	function setTab(tab: tab): void {
+		sessionStorage.setItem('UserGroup.Tab', JSON.stringify(tab));
+		setTabState(tab);
+	}
 
 	React.useEffect(() => {
 		if (status == 'unintiated' || status == 'changed')
@@ -77,7 +93,7 @@ function UserGroup(props: IProps) {
 			</div>
 			<LoadingScreen Show={status === 'loading'} />
 			<hr />
-			<TabSelector CurrentTab={tab} SetTab={(t) => setTab(t)} Tabs={Tabs} />
+			<TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
 			<div className="tab-content" style={{ maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
 				<div className={"tab-pane " + (tab === "info" ? " active" : "fade")}>
 					<GroupInfo Group={group} />

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/UserGroup/UserGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/User/UserGroup/UserGroup.tsx
@@ -22,11 +22,8 @@
 
 import * as React from 'react';
 import { LoadingScreen, ServerErrorIcon, TabSelector, Warning } from '@gpa-gemstone/react-interactive';
-import { Application, SystemCenter } from '@gpa-gemstone/application-typings';
 import * as _ from 'lodash';
-
 import { useAppDispatch, useAppSelector } from '../../hooks';
-import { CheckBox } from '@gpa-gemstone/react-forms';
 import { useHistory } from "react-router-dom";
 import { SecurityGroupSlice } from '../../Store/Store';
 import { ISecurityGroup } from '../Types';
@@ -34,25 +31,19 @@ import GroupInfo from './Info';
 import GroupUser from './GroupUsers';
 import GroupPermission from './Permissions';
 
-declare type tab = 'info' | 'users' | 'roles'
+declare type Tab = 'info' | 'users' | 'roles'
 
-interface IProps {
-	GroupID: string,
-	Tab: tab
-}
+interface IProps { GroupID: string,	Tab: Tab }
 
 function UserGroup(props: IProps) {
 	const history = useHistory();
 	const dispatch = useAppDispatch();
-
 	const group: ISecurityGroup = useAppSelector((state) => SecurityGroupSlice.Datum(state, props.GroupID) as ISecurityGroup);
 	const status = useAppSelector(SecurityGroupSlice.Status);
-
-	const [tab, setTabState] = React.useState<string>(getTab())
-
+	const [tab, setTab] = React.useState(getTab());
 	const [showWarning, setShowWarning] = React.useState<boolean>(false);
 
-	function getTab(): tab {
+	function getTab(): Tab {
 		if (props.Tab != undefined) return props.Tab;
 		else if (sessionStorage.hasOwnProperty('UserGroup.Tab'))
 			return JSON.parse(sessionStorage.getItem('UserGroup.Tab'));
@@ -60,10 +51,11 @@ function UserGroup(props: IProps) {
 			return 'info';
 	}
 
-	function setTab(tab: tab): void {
-		sessionStorage.setItem('UserGroup.Tab', JSON.stringify(tab));
-		setTabState(tab);
-	}
+	React.useEffect(() => {
+		const saved = getTab();
+		if (saved !== tab)
+			sessionStorage.setItem('UserGroup.Tab', JSON.stringify(tab));
+	}, [tab]);
 
 	React.useEffect(() => {
 		if (status == 'unintiated' || status == 'changed')
@@ -76,7 +68,7 @@ function UserGroup(props: IProps) {
 		</div>;
 
 	const Tabs = [
-		{ Id: "info", Label: "Info" },
+		{ Id: "info", Label: "User Group Info" },
 		{ Id: "users", Label: "Users" },
 		{ Id: "roles", Label: "Roles" }
 	];
@@ -93,7 +85,8 @@ function UserGroup(props: IProps) {
 			</div>
 			<LoadingScreen Show={status === 'loading'} />
 			<hr />
-			<TabSelector CurrentTab={tab} SetTab={setTab} Tabs={Tabs} />
+
+			<TabSelector CurrentTab={tab} SetTab={(t: Tab) => setTab(t)} Tabs={Tabs} />
 			<div className="tab-content" style={{ maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
 				<div className={"tab-pane " + (tab === "info" ? " active" : "fade")}>
 					<GroupInfo Group={group} />
@@ -104,8 +97,8 @@ function UserGroup(props: IProps) {
 				<div className={"tab-pane " + (tab === "roles" ? " active" : "fade")} style={{ maxHeight: window.innerHeight - 215 }}>
 					{group != null ? <GroupPermission GroupID={group.ID} /> : null }
 				</div>
-
 			</div>
+
 			<Warning Message={'This will permanently delete the User Group. Users in this Group will not be deleted, but may lose their roles. Are you sure you want to continue?'} Title={'Delete ' + (group?.DisplayName ?? 'User Group')} Show={showWarning} CallBack={(c) => {
 				setShowWarning(false);
 				if (c) {

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ValueListGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ValueListGroup.tsx
@@ -32,15 +32,29 @@ import { ValueListGroupSlice } from '../Store/Store';
 import { TabSelector, Warning } from '@gpa-gemstone/react-interactive';
 
 declare var homePath: string;
+declare type tab = 'info' | 'items'
 
-export default function ValueListGroup(props: { GroupID: number }) {
+export default function ValueListGroup(props: { GroupID: number, Tab: tab }) {
     const dispatch = useAppDispatch();
     const record = useAppSelector((state) => ValueListGroupSlice.Datum(state, props.GroupID));
 
     const valueListGroupStatus = useAppSelector(ValueListGroupSlice.Status);
 
-    const [tab, setTab] = React.useState<'items' | 'info'>('items');
+    const [tab, setTabState] = React.useState<tab>(getTab());
     const [showRemove, setShowRemove] = React.useState<boolean>(false);
+
+    function getTab(): tab {
+        if (props.Tab != undefined) return props.Tab;
+        else if (sessionStorage.hasOwnProperty('ValueListGroup.Tab'))
+            return JSON.parse(sessionStorage.getItem('ValueListGroup.Tab'));
+        else
+            return 'info';
+    }
+
+    function setTab(tab: tab): void {
+        sessionStorage.setItem('ValueListGroup.Tab', JSON.stringify(tab));
+        setTabState(tab);
+    }
 
     React.useEffect(() => {
         if (valueListGroupStatus == 'unintiated' || valueListGroupStatus == 'changed')
@@ -49,10 +63,6 @@ export default function ValueListGroup(props: { GroupID: number }) {
         return function () {
         }
     }, [dispatch, valueListGroupStatus]);
-
-    React.useEffect(() => {
-        sessionStorage.setItem('ValueListGroup.Tab', JSON.stringify(tab));
-    }, [tab]);
 
     function Delete() {
         dispatch(ValueListGroupSlice.DBAction({ verb: 'DELETE', record }))
@@ -72,9 +82,8 @@ export default function ValueListGroup(props: { GroupID: number }) {
                 </div>
             </div>
 
-
             <hr />
-            <TabSelector CurrentTab={tab} SetTab={(t) => setTab(t as ('items' | 'info'))} Tabs={[{ Label: 'Value List Group Info', Id: 'info' }, { Label: 'List Items', Id: 'items'}]} />
+            <TabSelector CurrentTab={tab} SetTab={setTab} Tabs={[{ Label: 'Value List Group Info', Id: 'info' }, { Label: 'List Items', Id: 'items'}]} />
 
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "info" ? " active" : "fade")} id="info">

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ValueListGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ValueListGroup/ValueListGroup.tsx
@@ -21,8 +21,6 @@
 //
 //******************************************************************************************************
 
-
-
 import * as React from 'react';
 import * as _ from 'lodash';
 import ValueListGroupInfo from './ValueListGroupInfo';
@@ -32,18 +30,18 @@ import { ValueListGroupSlice } from '../Store/Store';
 import { TabSelector, Warning } from '@gpa-gemstone/react-interactive';
 
 declare var homePath: string;
-declare type tab = 'info' | 'items'
+declare type Tab = 'info' | 'items'
 
-export default function ValueListGroup(props: { GroupID: number, Tab: tab }) {
+interface IProps { GroupID: number, Tab: Tab }
+
+export default function ValueListGroup(props: IProps) {
     const dispatch = useAppDispatch();
     const record = useAppSelector((state) => ValueListGroupSlice.Datum(state, props.GroupID));
-
     const valueListGroupStatus = useAppSelector(ValueListGroupSlice.Status);
-
-    const [tab, setTabState] = React.useState<tab>(getTab());
+    const [tab, setTab] = React.useState(getTab());
     const [showRemove, setShowRemove] = React.useState<boolean>(false);
 
-    function getTab(): tab {
+    function getTab(): Tab {
         if (props.Tab != undefined) return props.Tab;
         else if (sessionStorage.hasOwnProperty('ValueListGroup.Tab'))
             return JSON.parse(sessionStorage.getItem('ValueListGroup.Tab'));
@@ -51,15 +49,15 @@ export default function ValueListGroup(props: { GroupID: number, Tab: tab }) {
             return 'info';
     }
 
-    function setTab(tab: tab): void {
-        sessionStorage.setItem('ValueListGroup.Tab', JSON.stringify(tab));
-        setTabState(tab);
-    }
+    React.useEffect(() => {
+        const saved = getTab();
+        if (saved !== tab)
+            sessionStorage.setItem('ValueListGroup.Tab', JSON.stringify(tab));
+    }, [tab]);
 
     React.useEffect(() => {
         if (valueListGroupStatus == 'unintiated' || valueListGroupStatus == 'changed')
             dispatch(ValueListGroupSlice.Fetch());
-
         return function () {
         }
     }, [dispatch, valueListGroupStatus]);
@@ -78,13 +76,12 @@ export default function ValueListGroup(props: { GroupID: number, Tab: tab }) {
                 </div>
                 <div className="col">
                     <button className="btn btn-danger pull-right" hidden={record == null}
-                        onClick={() => setShowRemove(true)}>Delete Value List Group (Permanent)</button>
+                        onClick={() => setShowRemove(true)}>Delete Value List Group</button>
                 </div>
             </div>
-
             <hr />
-            <TabSelector CurrentTab={tab} SetTab={setTab} Tabs={[{ Label: 'Value List Group Info', Id: 'info' }, { Label: 'List Items', Id: 'items'}]} />
 
+            <TabSelector CurrentTab={tab} SetTab={(t:Tab) => setTab(t)} Tabs={[{ Label: 'Value List Group Info', Id: 'info' }, { Label: 'List Items', Id: 'items'}]} />
             <div className="tab-content" style={{ maxHeight: window.innerHeight - 235, overflow: 'hidden' }}>
                 <div className={"tab-pane " + (tab == "info" ? " active" : "fade")} id="info">
                     <ValueListGroupInfo Record={record} />
@@ -93,6 +90,7 @@ export default function ValueListGroup(props: { GroupID: number, Tab: tab }) {
                     <ValueListGroupItems Record={record} />
                 </div>
             </div>
+
             <Warning
                 Message={'This will permanently delete this Value List Group and cannot be undone.'}
                 Show={showRemove} Title={'Delete ' + (record?.Name ?? 'Value List Group')}
@@ -100,4 +98,3 @@ export default function ValueListGroup(props: { GroupID: number, Tab: tab }) {
         </div>
     )
 }
-


### PR DESCRIPTION
Ticket_1501

Fix tab caching functionality so that the application remembers the previous selection for `Meters`, `Substations`, `Application Categories`, `Value Lists`, `Users`, and `User Groups`. This addresses the issue with the new `Configuration History` button not returning the user to the expected tab in the above mentioned ticket.