### PR TITLE
Added init flag to submodule update

### DIFF
--- a/Build/Scripts/SystemCenter.buildproj
+++ b/Build/Scripts/SystemCenter.buildproj
@@ -94,7 +94,7 @@
   </Target>
   <Target Name="AfterUpdateRepository">
       <Message Text="Getting latest updates from submodule..."/>
-      <Exec Command="%22$(GitClient)%22 submodule update --recursive" WorkingDirectory="$(LocalFolder)" Condition="'$(SetUpWorkspace)' != 'False'"/>
+      <Exec Command="%22$(GitClient)%22 submodule update --recursive --init" WorkingDirectory="$(LocalFolder)" Condition="'$(SetUpWorkspace)' != 'False'"/>
   </Target>
 
 

--- a/Build/Scripts/UpdateDependencies.bat
+++ b/Build/Scripts/UpdateDependencies.bat
@@ -69,7 +69,7 @@ ECHO Updating to latest version...
 "%git%" fetch
 "%git%" reset --hard origin/master
 "%git%" clean -f -d -x
-"%git%" submodule update --recursive
+"%git%" submodule update --recursive --init
 GOTO UpdateDependencies
 
 :UpdateDependencies


### PR DESCRIPTION
Added the --init flag since it may be the first build after cloning the repository in which case it is necessary to initialize submodules.
I verified that it does not cause any issues if it is already initialized.
