### PR TITLE
SC-140 Reset Button resets error states

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/NewMeterWizard.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/NewMeterWizard.tsx
@@ -1,4 +1,4 @@
-﻿//******************************************************************************************************
+//******************************************************************************************************
 //  NewMeterWizard.tsx - Gbtc
 //
 //  Copyright © 2020, Grid Protection Alliance.  All Rights Reserved.
@@ -332,7 +332,8 @@ export default function NewMeterWizard(props: {IsEngineer: boolean}) {
         setChannels(getChannels());
         setCurrentStep(getCurrentStep());
         setAssets(getAssets());
-
+        setStatus('unintiated');
+        setError([])
         //Take us back to meter page when done
         if (currentStep > saveStep)
             returnToMeters();
@@ -435,23 +436,29 @@ export default function NewMeterWizard(props: {IsEngineer: boolean}) {
             case eventChannelsStep:
                 // The uses the same page as the next step for now
             case trendChannelsStep:
-                return <ChannelPage IsEngineer={props.IsEngineer}  MeterKey={meterInfo.AssetKey} Channels={channels} UpdateChannels={setChannels} UpdateAssets={setAssets} SetError={setError} SetWarning={setWarning} TrendChannels={currentStep == 4} />
+                return <ChannelPage IsEngineer={props.IsEngineer}  MeterKey={meterInfo.AssetKey} Channels={channels} UpdateChannels={setChannels} 
+                    UpdateAssets={setAssets} SetError={setError} SetWarning={setWarning} TrendChannels={currentStep == 4} />
             case assetStep:
-                return <AssetPage AssetConnections={assetConnections} Location={locationInfo} Channels={channels} Assets={assets} UpdateChannels={setChannels} UpdateAssets={setAssets} UpdateAssetConnections={setAssetConnections} SetWarning={setWarning} PageID={assetPageID} />
+                return <AssetPage AssetConnections={assetConnections} Location={locationInfo} Channels={channels} Assets={assets} UpdateChannels={setChannels} 
+                    UpdateAssets={setAssets} UpdateAssetConnections={setAssetConnections} SetWarning={setWarning} PageID={assetPageID} />
             case connectionStep:
-                return <MultipleAssetsPage SkipExisting={false} Assets={assets.filter(asset => asset.AssetType != 'LineSegment')} GetInnerComponent={(currentAsset) => <ConnectionPage AllAssets={assets} CurrentAsset={currentAsset} AssetConnections={assetConnections} UpdateAssetConnections={setAssetConnections} />} />
+                return <MultipleAssetsPage SkipExisting={false} Assets={assets.filter(asset => asset.AssetType != 'LineSegment')} 
+                    GetInnerComponent={(currentAsset) => <ConnectionPage AllAssets={assets} CurrentAsset={currentAsset} AssetConnections={assetConnections} UpdateAssetConnections={setAssetConnections} />} />
             case additionalFieldMeterStep:
                 return <AdditionalFieldsWindow ID={meterID} Type='Meter' HideExternal={true} InnerOnly={true} />
             case externalFieldStep:
                 return <ExternalDBUpdate ID={meterID} Type='Meter'/>
             case lineSegmentStep:
-                return <MultipleAssetsPage Assets={lines} SkipExisting={false} GetInnerComponent={(currentAsset) => <LineSegmentWindow ID={currentAsset.ID} LineKey={currentAsset.AssetKey} LineName={currentAsset.AssetName} InnerOnly={true} />} />
+                return <MultipleAssetsPage Assets={lines} SkipExisting={false} GetInnerComponent={(currentAsset) => <LineSegmentWindow ID={currentAsset.ID} 
+                    LineKey={currentAsset.AssetKey} LineName={currentAsset.AssetName} InnerOnly={true} />} />
             case additionalFieldAssetStep:
-                return <MultipleAssetsPage Assets={assets} SkipExisting={true} GetInnerComponent={(currentAsset) => <AdditionalFieldsWindow ID={currentAsset.ID} Type={currentAsset.AssetType} InnerOnly={true} HideExternal={true} />}/>
+                return <MultipleAssetsPage Assets={assets} SkipExisting={true} GetInnerComponent={(currentAsset) => <AdditionalFieldsWindow ID={currentAsset.ID} 
+                    Type={currentAsset.AssetType} InnerOnly={true} HideExternal={true} />}/>
             case customerAssetGroupMeterStep:
                 return <CustomerAssetGroupPage ID={meterID} Type={'Meter'} Name={meterInfo.AssetKey} SetWarning={setWarning} />
             case customerAssetGroupAssetStep:
-                return <MultipleAssetsPage Assets={assets} SkipExisting={true} GetInnerComponent={(currentAsset) => <CustomerAssetGroupPage ID={currentAsset.ID} Type={'Asset'} Name={currentAsset.AssetKey} SetWarning={setWarning} />} />
+                return <MultipleAssetsPage Assets={assets} SkipExisting={true} GetInnerComponent={(currentAsset) => <CustomerAssetGroupPage ID={currentAsset.ID} 
+                    Type={'Asset'} Name={currentAsset.AssetKey} SetWarning={setWarning} />} />
         }
     };
 


### PR DESCRIPTION
Uses the `setState` to set the NMW state, and uses `setError` to set the error states in the child components.
tested with this code:
```typescript
function causeError(): void {
    setError(['error']);
}
```
```typescript
/*line 500*/ <button className="btn btn-block btn-danger pull-right" onClick={causeError}>Force Error</button>
```
to cause an error state and then reset it with the reset button.