### PR TITLE
Sc 241

### DIFF
--- a/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
@@ -1356,6 +1356,9 @@ namespace SystemCenter.Controllers
                         case "AN": case "BN": case "CN":
                             phase = phaseMatch;
                             break;
+                        case "N":
+                            phase = "NG";
+                            break;
                     }
                 }
 

--- a/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
@@ -1334,7 +1334,7 @@ namespace SystemCenter.Controllers
                 });
 
                 string phase = "None";
-                GroupCollection phaseMatchGroup = Regex.Match(channelName, @"(?<=[VI])(\S*)$", RegexOptions.IgnoreCase).Groups;
+                GroupCollection phaseMatchGroup = Regex.Match(channelName, @"(?<=\s\-\s[VI])(\S*)$", RegexOptions.IgnoreCase).Groups;
                 if(phaseMatchGroup.Count > 0)
                 {
                     string phaseMatch = phaseMatchGroup[0].Value.ToUpper();


### PR DESCRIPTION
- Add check for neutral channels and assign phase `NG`.
- Improve regex to include ` - ` before the channel type and phase designation to attempt to prevent undesired matches.
Tested with CTL file that contains NG and LN channels and the latest naming convention.