### PR TITLE
SC-252 NMW Tables

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
@@ -400,20 +400,20 @@ export default function AssetPage(props: IProps) {
                                         > Status
                                         </Column>
                                         <Column<AssetType>
-                                            Key={'AssetKey'}
-                                            AllowSort={true}
-                                            Field={'AssetKey'}
-                                            HeaderStyle={{ width: '20%' }}
-                                            RowStyle={{ width: '20%' }}
-                                        > Key
-                                        </Column>
-                                        <Column<AssetType>
                                             Key={'AssetName'}
                                             AllowSort={true}
                                             Field={'AssetName'}
                                             HeaderStyle={{ width: '30%' }}
                                             RowStyle={{ width: '30%' }}
                                         > Name
+                                        </Column>
+                                        <Column<AssetType>
+                                            Key={'AssetKey'}
+                                            AllowSort={true}
+                                            Field={'AssetKey'}
+                                            HeaderStyle={{ width: '20%' }}
+                                            RowStyle={{ width: '20%' }}
+                                        > Key
                                         </Column>
                                         <Column<AssetType>
                                             Key={'AssetType'}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
@@ -146,12 +146,7 @@ export default function ChannelPage(props: IProps) {
 
     React.useEffect(() => {
         setCurrentChannels((d) => {
-            if (sortKey == 'Series') {
-                const u = _.cloneDeep(d);
-                u.sort((a, b) => (asc ? 1 : -1) * (a.Series[0].SourceIndexes > b.Series[0].SourceIndexes ? 1 : -1));
-                return u;
-            }
-            return _.orderBy(d, [sortKey], [(!asc ? "asc" : "desc")]);
+            return sortChannels(d)
         })
     }, [sortKey, asc])
 
@@ -162,6 +157,15 @@ export default function ChannelPage(props: IProps) {
             e.push('No event channels are configured.');
         props.SetWarning(e);
     }, [currentChannels]);
+
+    const sortChannels = (channels: OpenXDA.Types.Channel[]) => {
+        if (sortKey == 'Series') {
+            const c = _.cloneDeep(channels);
+            c.sort((a, b) => (asc ? 1 : -1) * (a.Series[0].SourceIndexes > b.Series[0].SourceIndexes ? 1 : -1));
+            return c;
+        }
+        return _.orderBy(channels, [sortKey], [(!asc ? "asc" : "desc")]);
+    }
 
     const ParseFile = React.useCallback((content: ArrayBuffer, fileName: string) => {
         let extension = fileName.toLowerCase().substring(fileName.lastIndexOf('.') + 1, fileName.length);
@@ -193,7 +197,8 @@ export default function ChannelPage(props: IProps) {
                 cache: false,
                 async: true
             }).done((data: OpenXDA.Types.Channel[]) => {
-                handleParsedChannels(data);
+                const channels = sortChannels(data);
+                handleParsedChannels(channels);
                 // Need to fetch these after since the server parser will add new things to these if it spots them
                 dispatch(PhaseSlice.SetChanged());
                 dispatch(MeasurementCharacteristicSlice.SetChanged());
@@ -493,6 +498,7 @@ export default function ChannelPage(props: IProps) {
                     else
                         setAsc(false);
                     setSortKey(d.colKey);
+                    console.log(sortKey)
                 }}
             >
                 <ConfigurableColumn Key='Series' Label='Channel' Default={true}>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/ChannelPage.tsx
@@ -66,7 +66,7 @@ export default function ChannelPage(props: IProps) {
     const [listStatus, setListStatus] = React.useState<Application.Types.Status>('idle');
 
     const [sortKey, setSortKey] = React.useState<string>('Series');
-    const [asc, setAsc] = React.useState<boolean>(false);
+    const [asc, setAsc] = React.useState<boolean>(true);
 
     const phases = useAppSelector(PhaseSlice.Data);
     const measurementCharateristics = useAppSelector(MeasurementCharacteristicSlice.Data);
@@ -484,9 +484,7 @@ export default function ChannelPage(props: IProps) {
                 Data={currentChannels}
                 SortKey={sortKey}
                 Ascending={asc}
-                TheadStyle={{ fontSize: 'smaller', tableLayout: 'fixed', display: 'table', width: '100%' }}
-                TbodyStyle={{ display: 'block', overflowY: 'auto', flex: 1 }}
-                RowStyle={{ display: 'table', tableLayout: 'fixed', width: '100%' }}
+                TheadStyle={{ fontSize: 'smaller' }}
                 Selected={() => false}
                 KeySelector={(item) => item.ID}
                 OnSort={(d) => {
@@ -497,6 +495,21 @@ export default function ChannelPage(props: IProps) {
                     setSortKey(d.colKey);
                 }}
             >
+                <ConfigurableColumn Key='Series' Label='Channel' Default={true}>
+                    <Column<OpenXDA.Types.Channel>
+                        Key={'Series'}
+                        Adjustable={true}
+                        AllowSort={true}
+                        HeaderStyle={{ width: 'auto' }}
+                        RowStyle={{ width: 'auto' }}
+                        Content={({ item }) => <Input<OpenXDA.Types.Series> Field={'SourceIndexes'}
+                            Record={item.Series[0]} Setter={(series) => {
+                                item.Series[0].SourceIndexes = series.SourceIndexes;
+                                editChannel(item)
+                            }} Label={''} Valid={() => true} />}
+                    > Identifier
+                    </Column>
+                </ConfigurableColumn>
                 <Column<OpenXDA.Types.Channel>
                     Key={'Name'}
                     Adjustable={true}
@@ -508,21 +521,6 @@ export default function ChannelPage(props: IProps) {
                         Record={item} Valid={() => true} Setter={(ch) => editChannel(ch)} Label={''} />}
                 > Label
                 </Column>
-                <ConfigurableColumn Key='Series' Label='Channel' Default={true}>
-                    <Column<OpenXDA.Types.Channel>
-                        Key={'Series'}
-                        Adjustable={true}
-                        AllowSort={true}
-                        HeaderStyle={{width: 'auto'}}
-                        RowStyle={{width: 'auto'}}
-                        Content={({ item }) => <Input<OpenXDA.Types.Series> Field={'SourceIndexes'}
-                            Record={item.Series[0]} Setter={(series) => {
-                                item.Series[0].SourceIndexes = series.SourceIndexes;
-                                editChannel(item)
-                            }} Label={''} Valid={() => true} />}
-                    > Identifier
-                    </Column>
-                </ConfigurableColumn>
                 <ConfigurableColumn Key='MeasurementType' Label='Type' Default={false}>
                     <Column<OpenXDA.Types.Channel>
                         Key={'MeasurementType'}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Store/Store.ts
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Store/Store.ts
@@ -72,7 +72,7 @@ export const MeasurementCharacteristicSlice = new GenericSlice<OpenXDA.Types.Mea
 
 export const DataFileSlice = new GenericSlice<OpenXDA.Types.DataFile>("DataFile", `${homePath}api/OpenXDA/DataFile`, "ProcessingEndTime", false);
 export const EventTypeAssetTypeSlice = new GenericSlice<OpenXDA.Types.EventTypeAssetType>("EventTypeAssetType", `${homePath}api/OpenXDA/EventTypeAssetType`, "ID", false);
-export const CustomerSlice = new GenericSlice<OpenXDA.Types.Customer>("Customer", `${homePath}api/SystemCenter/Customer`, "CustomerKey", false);
+export const CustomerSlice = new GenericSlice<OpenXDA.Types.Customer>("Customer", `${homePath}api/SystemCenter/Customer`, "Name", true);
 export const CustomerMeterSlice = new GenericSlice<LocalXDA.CustomerMeter>('CustomerMeter', `${homePath}api/SystemCenter/CustomerMeter`, 'MeterName', true);
 export const CustomerAssetSlice = new GenericSlice<LocalXDA.CustomerAsset>('CustomerAsset', `${homePath}api/SystemCenter/CustomerAsset`, 'AssetName', true);
 


### PR DESCRIPTION
<h4>Jira Issue</h4>  

<h6>SC-252</h6>

---
<h4>Description</h4>  

<h6>New Meter Wizard Tables</h6>  
Columns are sorted to be more consistent and sorted column is updated.  <br />

---
<h4>Test</h4>  

**Test Table Sorting**  
1. Open SystemCenter
2. Click Add Meter
3. Continue to step 3 Channel
4. Upload a test file
5. Verify that Identifier is still sorted col and is ascending
7. Continue to step 9
8. Click Assign
9. Verify Customer table is sorted by name ascending
