### PR TITLE
Removed links, added onclick

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
@@ -29,6 +29,7 @@ import BreakerAttributes from '../AssetAttribute/Breaker';
 import CapBankAttributes from '../AssetAttribute/CapBank';
 import LineAttributes from '../AssetAttribute/Line';
 import TransformerAttributes from '../AssetAttribute/Transformer';
+import { useNavigate } from 'react-router-dom';
 import { AssetAttributes } from '../AssetAttribute/Asset';
 import { getAssetTypes, getAssetWithAdditionalFields } from '../../../TS/Services/Asset';
 import { DBActionAsset, DBMeterAction, SelectAssetStatus } from '../Store/AssetSlice'
@@ -48,6 +49,8 @@ declare var homePath: string;
 interface IProps { Meter: OpenXDA.Types.Meter }
 
 const MeterAssetWindow = (props: IProps) => {
+    const navigate = useNavigate();
+
     const MeterAssetController = new GenericController<OpenXDA.Types.MeterAsset>(`${homePath}api/OpenXDA/DetailedMeterAsset/${props.Meter.ID}`, "AssetName", true);
     const PagingID = 'MeterAssetPage'
 
@@ -150,10 +153,9 @@ const MeterAssetWindow = (props: IProps) => {
                                     setSortKey(d.colKey as keyof OpenXDA.Types.Asset);
                                 }
                             }}
-                            TableStyle={{ tableLayout: 'fixed', display: 'flex', flexDirection: 'column', overflow: 'hidden', flex: 1 }}
-                            TheadStyle={{ fontSize: 'smaller', display: 'table', tableLayout: 'fixed', width: '100%' }}
-                            TbodyStyle={{ display: 'block', width: '100%', overflowY: 'auto', flex: 1 }}
-                            RowStyle={{ fontSize: 'smaller', display: 'table', tableLayout: 'fixed', width: '100%' }}
+                            OnClick={ (c) => navigate(`${homePath}index.cshtml?name=Asset&AssetID=${c.row.ID}`) }
+                            TheadStyle={{ fontSize: 'smaller' }}
+                            RowStyle={{ fontSize: 'smaller' }}
                             Selected={(item) => false}
                             KeySelector={(item) => item.ID}
                         >
@@ -171,10 +173,6 @@ const MeterAssetWindow = (props: IProps) => {
                                 Field={'AssetKey'}
                                 HeaderStyle={{ width: 'auto' }}
                                 RowStyle={{ width: 'auto' }}
-                                Content={({ item, field }) =>
-                                <a href={`${homePath}index.cshtml?name=Asset&AssetID=${item.ID}`} target='_blank'>
-                                    {item[field]}
-                                </a>}
                             > Key
                             </Column>
                             <Column<OpenXDA.Types.MeterAsset>


### PR DESCRIPTION
<h4>Jira Issue</h4>  

<h6>SC-225</h6>

---
<h4>Description</h4>  

<h6>Meter Asset Links</h6>  
A previous PR had made this table just hyperlinks on the keys, but now the behavior is more standard. The entire row of the table links to the asset.  <br />

---
<h4>Test</h4>  

**Test Table Sorting**  
1. Open SystemCenter
2. Click Meter
3. Open a Meter
4. Click Asset Tab
5. Verify that clicking anywhere on the row will link to the asset, no hyperlinks