### PR TITLE
Table Page Goes Out of Bounds

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/ByAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/ByAsset.tsx
@@ -127,10 +127,14 @@ const ByAsset: Application.Types.iByComponent = (props) => {
     }, [newAsset]);
 
     React.useEffect(() => {
-        const storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
-        if (storedInfo == null) return;
+        let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+        if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+        if (storedInfo + 1 > pageInfo.NumberOfPages) {
+            storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+            localStorage.setItem(PagingID, `${storedInfo}`);
+        }
         setPage(storedInfo);
-    }, []);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     React.useEffect(() => {
         localStorage.setItem(PagingID, JSON.stringify(page));

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/CommonComponents/GenericByPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/CommonComponents/GenericByPage.tsx
@@ -72,10 +72,14 @@ function GenericByPage<T extends U>(props: React.PropsWithChildren<IProps<T>>) {
     ), [addlFieldCols, props.Columns]);
 
     React.useEffect(() => {
-        const storedInfo = JSON.parse(localStorage.getItem(`${props.PagingID}/Page`) as string);
-        if (storedInfo == null) return;
+        let storedInfo = JSON.parse(localStorage.getItem(props.PagingID) as string);
+        if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+        if (storedInfo + 1 > pageInfo.NumberOfPages) {
+            storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+            localStorage.setItem(props.PagingID, `${storedInfo}`);
+        }
         setPage(storedInfo);
-    }, []);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     React.useEffect(() => {
         localStorage.setItem(`${props.PagingID}/Page`, JSON.stringify(page));

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ConfigurationHistory/ConfigurationHistory.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ConfigurationHistory/ConfigurationHistory.tsx
@@ -33,6 +33,7 @@ import { ToolTip, ServerErrorIcon, LoadingScreen } from '@gpa-gemstone/react-int
 
 declare var homePath: string;
 declare var ace: any;
+const PagingID = 'ConfigHistPage'
 
 function ConfigurationHistory(props: { MeterConfigurationID: number, MeterKey: string }) {
     const navigate = useNavigate();
@@ -53,6 +54,16 @@ function ConfigurationHistory(props: { MeterConfigurationID: number, MeterKey: s
     const [pageState, setPageState] = React.useState<'error' | 'idle' | 'loading'>('idle');
 
     const [height, setHeight] = React.useState<number>(0);
+
+        React.useEffect(() => {
+        let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+        if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+        if (storedInfo + 1 > pageInfo.NumberOfPages) {
+            storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+            localStorage.setItem(PagingID, `${storedInfo}`);
+        }
+        setPage(storedInfo);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     React.useLayoutEffect(() => {
         if (aceRef.current == null)

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/LineSegment/ByLineSegment.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/LineSegment/ByLineSegment.tsx
@@ -52,10 +52,14 @@ const ByLineSegment: Application.Types.iByComponent = (props) => {
     const extDbUpdateAll = React.useRef<() => (() => void)>(undefined);
 
     React.useEffect(() => {
-        const storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
-        if (storedInfo == null) return;
+        let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+        if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+        if (storedInfo + 1 > pageInfo.NumberOfPages) {
+            storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+            localStorage.setItem(PagingID, `${storedInfo}`);
+        }
         setPage(storedInfo);
-    }, []);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     React.useEffect(() => {
         localStorage.setItem(PagingID, JSON.stringify(page));
@@ -151,7 +155,7 @@ const ByLineSegment: Application.Types.iByComponent = (props) => {
                     </fieldset>
                 </li>
             </SearchBar>
-            <div className="row" style={{ flex: 1, overflow: 'hidden' }}>
+            <div className="row" style={{ flex: 1, overflow: 'auto' }}>
                 {
                     pageStatus === 'idle' ?
                         <Table<OpenXDA.Types.LineSegment>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationAsset.tsx
@@ -44,7 +44,7 @@ import StationBatteryAttributes from '../AssetAttribute/StationBattery';
 import { SelectRoles } from '../Store/UserSettings';
 
 declare var homePath: string;
-
+const PagingID = 'LocationAssetPage';
 
 function LocationAssetWindow(props: { Location: OpenXDA.Types.Location }): JSX.Element{
     let navigate = useNavigate();
@@ -104,6 +104,16 @@ function LocationAssetWindow(props: { Location: OpenXDA.Types.Location }): JSX.E
     }, [newEditAsset]);
 
     React.useEffect(() => { setNewEditAsset(editAsset) }, [editAsset]);
+
+    React.useEffect(() => {
+        let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+        if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+        if (storedInfo + 1 > pageInfo.NumberOfPages) {
+            storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+            localStorage.setItem(PagingID, `${storedInfo}`);
+        }
+        setPage(storedInfo);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     function getAssets(): JQuery.jqXHR<OpenXDA.Types.Asset[]> {
         setLStatus('loading');

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationDrawings.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationDrawings.tsx
@@ -57,9 +57,14 @@ const LocationDrawingsWindow = (props: { Location: OpenXDA.Types.Location }) => 
     const [pageState, setPageState] = React.useState<'error' | 'idle' | 'loading'>('idle');
 
     React.useEffect(() => {
-        const storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
-        if (storedInfo != null) setPage(storedInfo);
-    }, []);
+            let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+            if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+            if (storedInfo + 1 > pageInfo.NumberOfPages) {
+                storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+                localStorage.setItem(PagingID, `${storedInfo}`);
+            }
+            setPage(storedInfo);
+        }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     React.useEffect(() => {
         localStorage.setItem(PagingID, JSON.stringify(page));

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationMeter.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/LocationMeter.tsx
@@ -29,6 +29,7 @@ import { ServerErrorIcon, LoadingScreen } from '@gpa-gemstone/react-interactive'
 import { useNavigate } from "react-router-dom";
 
 declare var homePath: string;
+const PagingID = 'LocationMeterPage';
 
 function LocationMeterWindow(props: { Location: OpenXDA.Types.Location }): JSX.Element{
     let navigate = useNavigate();
@@ -44,6 +45,16 @@ function LocationMeterWindow(props: { Location: OpenXDA.Types.Location }): JSX.E
         setPageState('loading');
         getMeters();
     }, [props.Location.ID, page, sortField, ascending]);
+
+    React.useEffect(() => {
+        let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+        if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+        if (storedInfo + 1 > pageInfo.NumberOfPages) {
+            storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+            localStorage.setItem(PagingID, `${storedInfo}`);
+        }
+        setPage(storedInfo);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     function getMeters(): void {
         $.ajax({

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
@@ -88,10 +88,14 @@ const MeterAssetWindow = (props: IProps) => {
     }, []);
 
     React.useEffect(() => {
-        const storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
-        if (storedInfo == null) return;
-        setPage(storedInfo);
-    }, []);
+            let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+            if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+            if (storedInfo + 1 > pageInfo.NumberOfPages) {
+                storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+                localStorage.setItem(PagingID, `${storedInfo}`);
+            }
+            setPage(storedInfo);
+        }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     React.useEffect(() => {
         localStorage.setItem(PagingID, JSON.stringify(page));

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterConfigurationHistory.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterConfigurationHistory.tsx
@@ -29,6 +29,7 @@ import { ServerErrorIcon, LoadingScreen } from '@gpa-gemstone/react-interactive'
 import { useNavigate } from "react-router-dom";
 import moment from 'moment';
 declare var homePath: string;
+const PagingID = 'MeterConfigHistPage';
 declare interface MeterConfiguration {
     ID: number,
     Revision: string,
@@ -43,6 +44,15 @@ function MeterConfigurationHistoryWindow(props: { Meter: OpenXDA.Types.Meter }) 
     const [pageInfo, setPageInfo] = React.useState<{ RecordsPerPage: number, NumberOfPages: number, TotalRecords: number }>({ RecordsPerPage: 0, NumberOfPages: 0, TotalRecords: 0 });
     const [pageState, setPageState] = React.useState<'error' | 'idle' | 'loading'>('idle');
 
+    React.useEffect(() => {
+        let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+        if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+        if (storedInfo + 1 > pageInfo.NumberOfPages) {
+            storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+            localStorage.setItem(PagingID, `${storedInfo}`);
+        }
+        setPage(storedInfo);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
     React.useEffect(() => {
         getData();
     }, [props.Meter, page]);

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterMaintenance.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterMaintenance.tsx
@@ -70,9 +70,14 @@ const MeterMaintenanceWindow = (props: IProps) => {
     const defaultFormat = 'YYYY-MM-DD[T]hh:mm:ss';
 
     React.useEffect(() => {
-        const storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
-        if (storedInfo != null) setPage(storedInfo);
-    }, []);
+            let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+            if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+            if (storedInfo + 1 > pageInfo.NumberOfPages) {
+                storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+                localStorage.setItem(PagingID, `${storedInfo}`);
+            }
+            setPage(storedInfo);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     React.useEffect(() => {
         localStorage.setItem(PagingID, JSON.stringify(page));

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ProcessedFile/ByDataOperationsFailure.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ProcessedFile/ByDataOperationsFailure.tsx
@@ -31,6 +31,7 @@ import Reason from '../CommonComponents/Reason';
 
 const DataOperationFailureController = new GenericController<OpenXDA.Types.DataOperationFailure>(`${homePath}api/OpenXDA/DataOperationFailure`, "ID", true);
 const storageID = "ByDataOperationsFailure";
+const PagingID = 'ByDataOperationsFailurePage';
 
 interface IProps { FileGroupID: number }
 
@@ -48,6 +49,16 @@ function ByDataOperationsFailure(props: IProps) {
 
     const [hover, setHover] = React.useState<string|undefined>(undefined);
     const [allowStackTrace, setAllowStackTrace] = React.useState<boolean>(true);
+
+    React.useEffect(() => {
+            let storedInfo = JSON.parse(localStorage.getItem(PagingID) as string);
+            if (storedInfo == null || storedInfo == 0) return; // page 0 means it's on a real page
+            if (storedInfo + 1 > pageInfo.NumberOfPages) {
+                storedInfo = Math.max(0, pageInfo.NumberOfPages - 1);
+                localStorage.setItem(PagingID, `${storedInfo}`);
+            }
+            setPage(storedInfo);
+    }, [pageInfo.TotalRecords]); // Make sure user is still on a real page when data is deleted or filtered out
 
     // Handling filter storage between sessions (this will load/save filters for all filepaths as the same, this is by design)
     React.useEffect(() => {


### PR DESCRIPTION
<h4>SC-305</h4>  

*<h6>Table Page Goes Out of Bounds</h6>*

---
<h4>Description</h4>  

*<h6>If a user was on the last page of a table, and they reduced the number of pages needed to display the table such that there is no longer a need for the final page, i.e. deleting an item or adding a filter, the page would not update and the table would be blank. This adds a useEffect to pages with a `pageInfo` state to fix this. Also added a scrollbar to the `LineSegment` table while I was there.</h6>*  

---
<h4>Testing</h4>  
1. On updated pages go to table (this can be tested most directly on Asset page which has 2 pages and a filter)<br/>
2. Go to last page of table and then remove data on that page<br/>
3. Verify that you are redirected to a real table page  <br/>

> 2. One way to do this is to change the localStorage for the table and refresh the page. Usually the page is sticky, but this fix will actually update that storage to a real page. This will verify that the useEffect updates the page when ran to a real page.
