### PR TITLE
Fixed Pagination Bug 

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/ByLocation.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/ByLocation.tsx
@@ -98,7 +98,11 @@ const ByLocation: Application.Types.iByComponent = (props) => {
     React.useEffect(() => {
         if (searchStatus == 'changed' || searchStatus == 'unintiated')
             dispatch(ByLocationSlice.PagedSearch({ filter: searchFields, sortField: sortKey, ascending, page }));
-    }, [searchStatus, dispatch, searchFields, sortKey, ascending, page]);
+    }, [searchFields, searchStatus]);
+
+    React.useEffect(() => {
+        dispatch(ByLocationSlice.PagedSearch({ filter: searchFields, sortField: sortKey, ascending, page }));
+    }, [sortKey, ascending, page]);
 
     function getNewLocation() {
         return {

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/ByLocation.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/ByLocation.tsx
@@ -98,11 +98,11 @@ const ByLocation: Application.Types.iByComponent = (props) => {
     React.useEffect(() => {
         if (searchStatus == 'changed' || searchStatus == 'unintiated')
             dispatch(ByLocationSlice.PagedSearch({ filter: searchFields, sortField: sortKey, ascending, page }));
-    }, [searchFields, searchStatus]);
+    }, [searchStatus]);
 
     React.useEffect(() => {
         dispatch(ByLocationSlice.PagedSearch({ filter: searchFields, sortField: sortKey, ascending, page }));
-    }, [sortKey, ascending, page]);
+    }, [searchFields, sortKey, ascending, page]);
 
     function getNewLocation() {
         return {


### PR DESCRIPTION
<h4>Jira Issue(s)</h4>  

*<h6>Part of SC-305</h6>*

<br />

---
<h4>Description</h4>  

*<h6>The pagination on the Substation page did not switch pages. I've added a useEffect to do the proper PageSearch when necessary.</h6>*  

<h4>Testing</h4>  
1. You will need multiple pages in order to test page swapping.  </br>
2. Click through next pages with Paging component

> To get multiple pages with just the vmsqlhost data set I modified the `GSF.Web` file's `GetPagedList` function to 1 EntryPerPage instead of 50, built, and copied it over and this allowed for fewer entries per page, thus more pages. The front-end will still render all on the proper page (the first), but it will have more pages (as if there was just one entry per page). Correct behavior in this case is: Page one has all the entries, All the following pages are blank. *Prior behavior would show every page with every entry, evidence it was not really changing pages, just displaying the same data on each page*