### PR TITLE
SC-313

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/LineSegment/ByLineSegment.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/LineSegment/ByLineSegment.tsx
@@ -155,7 +155,6 @@ const ByLineSegment: Application.Types.iByComponent = (props) => {
                     </fieldset>
                 </li>
             </SearchBar>
-            <div className="row" style={{ flex: 1, overflow: 'auto' }}>
                 {
                     pageStatus === 'idle' ?
                         <Table<OpenXDA.Types.LineSegment>
@@ -227,7 +226,6 @@ const ByLineSegment: Application.Types.iByComponent = (props) => {
                             <ServerErrorIcon Show={pageStatus === 'error'} Size={40} Label={'A Server Error Occurred. Please Reload the Application.'} />
                         </>
                 }
-            </div>
             <div style={{width: '100%'}}>
                 <Paging Current={page + 1} Total={pageInfo.NumberOfPages} SetPage={(p) => setPage(p - 1)} />
             </div>


### PR DESCRIPTION
<h4>Jira Issue(s)</h4>  

*<h6>SC-313</h6>*


---
<h4>Description</h4>  

*<h6>There was a div that had a flexbox on it which was expanding the scroll bar. It has been eliminated.</h6>*  


---
<h4>Testing</h4>  

1.   Open SystemCenter
2.   Verify LineSegments page table has a scroll bar that does not extend past the `tbody` into the header