### PR TITLE
SC-261 Subscription Table

### DIFF
--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/Store.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/Store.tsx
@@ -47,7 +47,7 @@ export const AssetGroupSlice = new GenericSlice<OpenXDA.Types.AssetGroup>("Asset
 export const SettingSlice = new GenericSlice<SystemCenter.Types.Setting>('Setting', `${homePath}api/Setting`, 'Name');
 export const EventSubscriptionSlice = new GenericSlice<SubscribeEmails>('EventSubscription', `${homePath}api/EventSubscription`, 'FirstName');
 export const ReportSubscriptionSlice = new GenericSlice<SubscribeReports>('ReportSubscription', `${homePath}api/ReportSubscription`, 'FirstName');
-export const ActiveSubscriptionSlice = new GenericSlice<ActiveSubscription>('ActiveSubscription', `${homePath}api/ActiveSubscription`, 'Email');
+export const ActiveSubscriptionSlice = new GenericSlice<ActiveSubscription>('ActiveSubscription', `${homePath}api/ActiveSubscription`, 'LastSent');
 export const ActiveReportSubscriptionSlice = new GenericSlice<ActiveReportSubscription>('ActiveReportSubscription', `${homePath}api/ActiveScheduleSubscription`, 'Email');
 
 export const UserInfoSlice = new UserInfoSliceClass('UserInfo', `${homePath}api/UserInfo`);

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/ByAllSubscription.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/ByAllSubscription.tsx
@@ -196,7 +196,11 @@ const ByAllSubscription = (props: IProps) => {
                             Field={'LastSent'}
                             HeaderStyle={{ width: '10%' }}
                             RowStyle={{ width: '10%' }}
-                            Content={({ item }) => (item.Approved && item.LastSent != null) ? moment(item.LastSent).format("dd/MM/yy hh:mm") : "N/A" }
+                            Content={({ item }) =>
+                                item.RequireApproval ?
+                                    (item.Approved && item.LastSent != null) ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
+                                : item.LastSent != null ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
+                            }
                         > Last Sent
                         </Column>
                         <Column<ActiveSubscription>

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/ByAllSubscription.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/ByAllSubscription.tsx
@@ -196,11 +196,7 @@ const ByAllSubscription = (props: IProps) => {
                             Field={'LastSent'}
                             HeaderStyle={{ width: '10%' }}
                             RowStyle={{ width: '10%' }}
-                            Content={({ item }) =>
-                                item.RequireApproval ?
-                                    (item.Approved && item.LastSent != null) ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
-                                : item.LastSent != null ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
-                            }
+                            Content={({ item }) => item.LastSent != null && (!item.RequireApproval || item.Approved) ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"}
                         > Last Sent
                         </Column>
                         <Column<ActiveSubscription>

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/BySubscription.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/BySubscription.tsx
@@ -119,7 +119,11 @@ const BySubscription = (props: IProps) => {
                             Field={'LastSent'}
                             HeaderStyle={{ width: 'auto' }}
                             RowStyle={{ width: 'auto' }}
-                            Content={({ item }) => (item.Approved && item.LastSent != null) ? moment(item.LastSent).format("dd/MM/yy hh:mm") : "N/A" }
+                            Content={({ item }) =>
+                                item.RequireApproval ?
+                                    (item.Approved && item.LastSent != null) ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
+                                : item.LastSent != null ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
+                            }
                         > Last Sent
                         </Column>
                         <Column<ActiveSubscription>

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/BySubscription.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/Subscriptions/Event/BySubscription.tsx
@@ -119,11 +119,7 @@ const BySubscription = (props: IProps) => {
                             Field={'LastSent'}
                             HeaderStyle={{ width: 'auto' }}
                             RowStyle={{ width: 'auto' }}
-                            Content={({ item }) =>
-                                item.RequireApproval ?
-                                    (item.Approved && item.LastSent != null) ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
-                                : item.LastSent != null ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"
-                            }
+                            Content={({ item }) => item.LastSent != null && (!item.RequireApproval  || item.Approved) ? moment(item.LastSent).format("DD/MM/yy hh:mm") : "N/A"}
                         > Last Sent
                         </Column>
                         <Column<ActiveSubscription>
@@ -132,7 +128,7 @@ const BySubscription = (props: IProps) => {
                             Field={'Subject'}
                             HeaderStyle={{ width: 'auto' }}
                             RowStyle={{ width: 'auto' }}
-                            Content={({ item }) => (item.Approved && item.Subject != null) ? item.Subject : "N/A" }
+                            Content={({ item }) => (item.Subject != null && (!item.RequireApproval  || item.Approved)) ? item.Subject : "N/A" }
                         > Last Subject
                         </Column>
                         <Column<ActiveSubscription>


### PR DESCRIPTION
<h4>SC-261</h4>  


---
<h4>Description</h4>  

*<h6>The All Subscription and My Subscription tables were showing all of the emails sent. This is unintended and has been fixed. Now it only shows each email once. As the ticket describes.</h6>*  

---
<h4>Testing</h4>  

1.   Open SystemCenter Notifications
2. Go to My Subscriptions
3. (Given that you have subscriptions) This will display only one of each type
4. Go to All Subscriptions
5. Verify that displayed is only one of each subscription per user

---
<h5>Related PRs</h5>  

*<h6>[OpenXDA has the needed DB View changes](https://github.com/GridProtectionAlliance/openXDA/pull/461)</h6>*  
