### PR TITLE
SC-329 Don't ignore log messages from GSF if stack frame is missing

### DIFF
--- a/Source/Applications/SystemCenter/ServiceHost.cs
+++ b/Source/Applications/SystemCenter/ServiceHost.cs
@@ -1136,15 +1136,20 @@ namespace SystemCenter
                 if (logMessage.Level == MessageLevel.NA)
                     return;
 
+                string className = logMessage.TypeName;
+                string methodName = string.Empty;
+                string fileName = string.Empty;
+                string lineNumber = string.Empty;
                 LogStackFrame firstStackFrame = logMessage.CurrentStackTrace.Frames.FirstOrDefault();
 
-                if (firstStackFrame is null)
-                    return;
+                if (firstStackFrame is not null)
+                {
+                    className = firstStackFrame.ClassName;
+                    methodName = firstStackFrame.MethodName;
+                    fileName = firstStackFrame.FileName;
+                    lineNumber = firstStackFrame.LineNumber.ToString();
+                }
 
-                string className = firstStackFrame.ClassName;
-                string methodName = firstStackFrame.MethodName;
-                string fileName = firstStackFrame.FileName;
-                string lineNumber = firstStackFrame.LineNumber.ToString();
                 LocationInfo locationInfo = new LocationInfo(className, methodName, fileName, lineNumber);
 
                 LoggingEventData loggingData = new LoggingEventData();
@@ -1153,6 +1158,7 @@ namespace SystemCenter
                 loggingData.Level = ToLog4NetLevel(logMessage.Level);
                 loggingData.Message = logMessage.Message;
                 loggingData.LocationInfo = locationInfo;
+                loggingData.ExceptionString = logMessage.ExceptionString;
 
                 LoggingEvent loggingEvent = new LoggingEvent(loggingData);
                 appender.DoAppend(loggingEvent);


### PR DESCRIPTION
<h4>Jira Issue(s)</h4>  

SC-329

<br />

---
<h4>Description</h4>  

Includes log messages from GSF that do not have a stack frame. If there is no stack frame then we will not have any information about method name, file name, and line number. However, this is just a formality since we don't log that information in the debug logs anyway.

This also forwards the exception string along so that we can see the exception message and stack trace for exceptions that occur in GSF libraries.

<br />

---
<h4>How/Where to test OR Detail how it was tested</h4>  

1. Log into the System Center web interface
2. Navigate to the `Debug` folder in the System Center install path
3. Open the latest debug log and search for a message similar to the following

> 2025-06-10 15:06:06,799 [4] INFO  GSF.Security.AdoSecurityProvider - User "GPA\swills" login attempt succeeded using pass-through authentication.