### PR TITLE
NotificationPages fixes for AzureAD

### DIFF
--- a/Source/Applications/SystemCenterNotification/NotificationPages.csproj
+++ b/Source/Applications/SystemCenterNotification/NotificationPages.csproj
@@ -142,6 +142,10 @@
     </Reference>
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Text.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Dependencies\GSF\System.Text.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.Helpers">
       <HintPath>..\..\Dependencies\GSF\System.Web.Helpers.dll</HintPath>
     </Reference>

--- a/Source/Applications/SystemCenterNotification/Web.config
+++ b/Source/Applications/SystemCenterNotification/Web.config
@@ -15,8 +15,8 @@
       <add name="DebugLogLocation" value="Logs" description="The location to which debug logs will be written" encrypted="false" />
       <add name="DebugLogLevel" value="None" description="The verbosity level of messages to be captured in the debug log: None, Low, Medium, High, Ultra, All" encrypted="false" />
       <add name="AnonymousResourceExpression" value="^/Login|^/@|^/Scripts/|^/Content/|^/Images/|^/fonts/|^/favicon.ico$|^/api/jsonapi/" description="Expression that will match paths for the resources on the web server that can be provided without checking credentials." encrypted="false" />
-      <add name="LoginPage" value="/Login" description="Defines the login page used for redirects on authentication failure. Expects forward slash prefix." encrypted="false" />
-      <add name="LoginIcon" value="/@GSF/Web/Shared/Images/gpa-smalllock.png" description="Defines the login icon used on the login page." encrypted="false" />
+      <add name="LoginPage" value="~/Login" description="Defines the login page used for redirects on authentication failure. Expects forward slash prefix." encrypted="false" />
+      <add name="LoginIcon" value="@GSF/Web/Shared/Images/gpa-smalllock.png" description="Defines the login icon used on the login page." encrypted="false" />
       <add name="AuthTestPage" value="~/AuthTest" description="Defines the page name for the web server to test if a user is authenticated. Expects forward slash prefix." encrypted="false" />
       <add name="DefaultSecurityRoles" value="Administrator,Engineer,Viewer" description="The default security roles that should exist for the application." encrypted="false" />
       <add name="EmbeddedTemplatePath" value="GSF.Web.Model.Views." description="Embedded name space path for data context based razor field templates." encrypted="false" />

--- a/Source/Applications/SystemCenterNotification/appsettings.json
+++ b/Source/Applications/SystemCenterNotification/appsettings.json
@@ -5,8 +5,9 @@
 
     // Client ID (application ID) obtained from the Azure portal
     "ClientId": "1846d540-df04-4a34-9764-f56985e19eee",
-    "CallbackPath": "/signin-oidc",
-    "SignedOutCallbackPath": "/signout-oidc",
+    "RedirectURI": "~/",
+    "CallbackPath": "~/signin-oidc",
+    "SignedOutCallbackPath": "~/signout-oidc",
     "Enabled": true
   }
 }


### PR DESCRIPTION
Looks like I was still sitting on these changes from last week's testing.

* Adds necessary reference to `System.Text.Json` from GSF
* Adds tildes to web paths to reference endpoints out of the home path instead of the root path