### PR TITLE
Sc controller activation

### DIFF
--- a/Source/Applications/SystemCenter/Configuration/SystemSettings.cs
+++ b/Source/Applications/SystemCenter/Configuration/SystemSettings.cs
@@ -69,7 +69,7 @@ namespace SystemCenter.Configuration
         /// query is given to complete, in seconds.
         /// </summary>
         [Setting]
-        [DefaultValue(120)]
+        [DefaultValue(30)]
         public int DbTimeout { get; set; }
 
         #endregion

--- a/Source/Applications/SystemCenter/Controllers/ControllerActivator.cs
+++ b/Source/Applications/SystemCenter/Controllers/ControllerActivator.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Net.Http;
 using System.Reflection;
@@ -72,7 +73,15 @@ namespace openXDA.WebHosting
 
         private Func<IHttpController> BuildFactory(Type controllerType)
         {
+            // Look for category on controller type
             string connection = controllerType.GetCustomAttribute<SettingsCategoryAttribute>()?.SettingsCategory;
+            // Look for category on first model type, this should support settings categories on models for model controllers
+            if (connection is null)
+            {
+                Type[] genericArguments = controllerType.BaseType.GetGenericArguments();
+                if (genericArguments.Any())
+                    connection = genericArguments.First().GetCustomAttribute<SettingsCategoryAttribute>()?.SettingsCategory;
+            }
             Func<AdoDataConnection> connectionFactory = () => Program.Host.CreateDbConnection(connection);
 
             // Get connection factory constructor, failing that, try to create the default constructor and then allow us to set connection factory in the object

--- a/Source/Applications/SystemCenter/Controllers/ControllerActivator.cs
+++ b/Source/Applications/SystemCenter/Controllers/ControllerActivator.cs
@@ -1,0 +1,153 @@
+﻿//******************************************************************************************************
+//  ControllerActivator.cs
+//
+//  Copyright © 2025, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may not use this
+//  file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  07/30/2025 - Stephen C. Wills
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Reflection;
+using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
+using System.Web.UI.WebControls;
+using GSF.Data;
+using GSF.Data.Model;
+using log4net;
+using SystemCenter;
+
+namespace openXDA.WebHosting
+{
+    public class ControllerActivator : IHttpControllerActivator
+    {
+        #region [ Constructors ]
+
+        public ControllerActivator()
+        {
+            FactoryLookup = new ConcurrentDictionary<Type, Func<IHttpController>>();
+        }
+
+        #endregion
+
+        #region [ Properties ]
+
+        private ConcurrentDictionary<Type, Func<IHttpController>> FactoryLookup { get; }
+        private Func<AdoDataConnection> DefaultConnectionFactory => Program.Host.CreateDbConnection;
+        private ConcurrentDictionary<string, Func<AdoDataConnection>> m_registeredConnectionFactories = new ConcurrentDictionary<string, Func<AdoDataConnection>>();
+
+        #endregion
+
+        #region [ Methods ]
+
+        public IHttpController Create(HttpRequestMessage request, HttpControllerDescriptor controllerDescriptor, Type controllerType)
+        {
+            Func<IHttpController> factory =
+                LookUpFactory(controllerType) ??
+                BuildFactory(controllerType) ??
+                GetDefaultFactory(request, controllerDescriptor, controllerType);
+
+            FactoryLookup.TryAdd(controllerType, factory);
+            return factory();
+        }
+
+        private Func<IHttpController> LookUpFactory(Type controllerType) =>
+            FactoryLookup.TryGetValue(controllerType, out Func<IHttpController> factory)
+                ? factory
+                : null;
+
+        private Func<IHttpController> BuildFactory(Type controllerType)
+        {
+
+            Func<AdoDataConnection> connectionFactory;
+            string connection = controllerType.GetCustomAttribute<SettingsCategoryAttribute>()?.SettingsCategory;
+
+            //Create or get connection factory
+            if (connection is null)
+                connectionFactory = DefaultConnectionFactory;
+            else if (!m_registeredConnectionFactories.TryGetValue(connection, out connectionFactory))
+            {
+                MethodInfo getConnection = typeof(ServiceHost).GetMethod(nameof(Program.Host.CreateDbConnection), [typeof(string)]);
+                if (getConnection is null)
+                {
+                    Log.Error("Unable to retrieve method information to create db connection with connection string.");
+                    return null;
+                }
+
+                Expression connectionConst = Expression.Constant(connection);
+                Expression host = Expression.Constant(Program.Host);
+                MethodCallExpression callExpression = Expression.Call(host, getConnection, connectionConst);
+                UnaryExpression typedCallExpression = Expression.TypeAs(callExpression, typeof(AdoDataConnection));
+                BlockExpression blockCallExpression = Expression.Block(typedCallExpression);
+                LambdaExpression lambdaCallExpression = Expression.Lambda(blockCallExpression);
+                connectionFactory = (Func<AdoDataConnection>)lambdaCallExpression.Compile();
+                m_registeredConnectionFactories.TryAdd(connection, connectionFactory);
+            }
+
+            // Get connection factory constructor, failing that, try to create the default constructor and then allow us to set connection factory in the object
+            ConstructorInfo constructor = controllerType.GetConstructor([typeof(Func<AdoDataConnection>)]);
+            Expression constantExpression = Expression.Constant(connectionFactory);
+            BlockExpression blockExpression;
+            if (constructor is null)
+            {
+                constructor = controllerType.GetConstructor([]);
+                PropertyInfo connectionFactoryProperty = controllerType.GetProperty("ConnectionFactory", typeof(Func<AdoDataConnection>));
+                if (constructor is null || connectionFactoryProperty is null)
+                    return null;
+
+                //Create controller variable, construct, and assign property
+                ParameterExpression controller = Expression.Variable(controllerType);
+                BinaryExpression constructedController = Expression.Assign(controller, Expression.New(constructor));
+                BinaryExpression setExpression = Expression.Assign(Expression.Property(controller, connectionFactoryProperty), constantExpression);
+
+                // Cast to IHttpControlller and return from block
+                UnaryExpression typeAsExpression = Expression.TypeAs(controller, typeof(IHttpController));
+                blockExpression = Expression.Block(typeof(IHttpController), [controller], [constructedController, setExpression, typeAsExpression]);
+            }
+            else
+            {
+                NewExpression newExpression = Expression.New(constructor, constantExpression);
+                UnaryExpression typeAsExpression = Expression.TypeAs(newExpression, typeof(IHttpController));
+                blockExpression = Expression.Block(typeAsExpression);
+            }
+            LambdaExpression lambdaExpression = Expression.Lambda(blockExpression);
+
+
+            return (Func<IHttpController>)lambdaExpression.Compile();
+        }
+
+        private Func<IHttpController> GetDefaultFactory(HttpRequestMessage request, HttpControllerDescriptor controllerDescriptor, Type controllerType) =>
+            () => DefaultControllerActivator.Create(request, controllerDescriptor, controllerType);
+
+        #endregion
+
+        #region [ Static ]
+
+        // Static Properties
+        private static DefaultHttpControllerActivator DefaultControllerActivator { get; }
+            = new DefaultHttpControllerActivator();
+
+        private static readonly ILog Log = LogManager.GetLogger(typeof(ControllerActivator));
+
+        #endregion
+    }
+}

--- a/Source/Applications/SystemCenter/ServiceHost.cs
+++ b/Source/Applications/SystemCenter/ServiceHost.cs
@@ -742,6 +742,16 @@ namespace SystemCenter
             return $"UpdateExternal-{dbTask.ExternalDB.ID}";
         }
 
+        /// <summary>
+        /// Creates a db connection to the database, using timeout settings.
+        /// </summary>
+        public AdoDataConnection CreateDbConnection() => m_systemCenterEngine.CreateDbConnection();
+
+        /// <summary>
+        /// Creates a db connection to the database connection, using timeout settings.
+        /// </summary>
+        public AdoDataConnection CreateDbConnection(string category) => m_systemCenterEngine.CreateDbConnection(category);
+
         // Send the error to the service helper, error logger, and each service monitor
         public void HandleException(Exception ex)
         {

--- a/Source/Applications/SystemCenter/ServiceHost.cs
+++ b/Source/Applications/SystemCenter/ServiceHost.cs
@@ -743,14 +743,9 @@ namespace SystemCenter
         }
 
         /// <summary>
-        /// Creates a db connection to the database, using timeout settings.
-        /// </summary>
-        public AdoDataConnection CreateDbConnection() => m_systemCenterEngine.CreateDbConnection();
-
-        /// <summary>
         /// Creates a db connection to the database connection, using timeout settings.
         /// </summary>
-        public AdoDataConnection CreateDbConnection(string category) => m_systemCenterEngine.CreateDbConnection(category);
+        public AdoDataConnection CreateDbConnection(string? category = null) => m_systemCenterEngine.CreateDbConnection(category);
 
         // Send the error to the service helper, error logger, and each service monitor
         public void HandleException(Exception ex)

--- a/Source/Applications/SystemCenter/Startup.cs
+++ b/Source/Applications/SystemCenter/Startup.cs
@@ -24,6 +24,7 @@
 using System.Collections.Generic;
 using System.Web.Http;
 using System.Web.Http.Controllers;
+using System.Web.Http.Dispatcher;
 using System.Web.Http.Routing;
 using GSF.Configuration;
 using GSF.Web.Hosting;
@@ -33,6 +34,7 @@ using Microsoft.AspNet.SignalR.Json;
 using Microsoft.Owin.Cors;
 using Microsoft.Owin.Extensions;
 using Newtonsoft.Json;
+using openXDA.WebHosting;
 using Owin;
 using SystemCenter.Model;
 
@@ -93,6 +95,10 @@ namespace SystemCenter
 
             // Set configuration to use reflection to setup routes
             httpConfig.MapHttpAttributeRoutes(new CustomDirectRouteProvider());
+
+            // Override controller activation
+            ControllerActivator controllerActivator = new ControllerActivator();
+            httpConfig.Services.Replace(typeof(IHttpControllerActivator), controllerActivator);
 
             // Load the WebPageController class and assign its routes
             app.UseWebApi(httpConfig);

--- a/Source/Applications/SystemCenter/SystemCenter.csproj
+++ b/Source/Applications/SystemCenter/SystemCenter.csproj
@@ -273,6 +273,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controllers\ControllerActivator.cs" />
     <Compile Include="Controllers\ControllerHelpers.cs" />
     <Compile Include="Controllers\ExternalDB\ExternalModelController.cs" />
     <Compile Include="Controllers\ExternalDB\LineSegmentWizardController.cs" />

--- a/Source/Applications/SystemCenter/SystemCenterEngine.cs
+++ b/Source/Applications/SystemCenter/SystemCenterEngine.cs
@@ -69,6 +69,7 @@
 //*********************************************************************************************************************
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Configuration;
@@ -248,19 +249,15 @@ namespace SystemCenter
             m_systemSettings = new SystemSettings(LoadSystemSettings());
         }
 
-
-        /// <summary>
-        /// Creates a db connection to the default database, using timeout settings.
-        /// </summary>
-        public AdoDataConnection CreateDbConnection() => CreateDbConnection(DefaultCategory);
-
         /// <summary>
         /// Creates a db connection to the database, using timeout settings.
         /// </summary>
-        public AdoDataConnection CreateDbConnection(string settingsCategory)
+        public AdoDataConnection CreateDbConnection(string? settingsCategory = null)
         {
-            if (!m_connectionFactories.TryGetValue(settingsCategory, out DatabaseConnectionFactory factory))
-                factory = CreateAndAddFactory(ConfigurationFile.Current, settingsCategory);
+            string category = settingsCategory ?? DefaultCategory;
+
+            if (!m_connectionFactories.TryGetValue(category, out DatabaseConnectionFactory factory))
+                factory = CreateAndAddFactory(ConfigurationFile.Current, category);
 
             AdoDataConnection connection = factory.CreateDbConnection();
             if (m_systemSettings is not null)

--- a/Source/Applications/SystemCenter/SystemCenterEngine.cs
+++ b/Source/Applications/SystemCenter/SystemCenterEngine.cs
@@ -96,7 +96,7 @@ namespace SystemCenter
 
         // Fields
         private SystemSettings m_systemSettings;
-        private Dictionary<string, DatabaseConnectionFactory> m_connectionFactories;
+        private ConcurrentDictionary<string, DatabaseConnectionFactory> m_connectionFactories;
 
         // Constants
         private const string DefaultCategory = "systemSettings";
@@ -201,7 +201,7 @@ namespace SystemCenter
         public void Start()
         {
             // Create Connection factory object
-            m_connectionFactories = new Dictionary<string, DatabaseConnectionFactory>();
+            m_connectionFactories = new ConcurrentDictionary<string, DatabaseConnectionFactory>();
 
             // Get system settings from the database
             ReloadSystemSettings();

--- a/Source/Applications/SystemCenter/SystemCenterEngine.cs
+++ b/Source/Applications/SystemCenter/SystemCenterEngine.cs
@@ -68,28 +68,18 @@
 //
 //*********************************************************************************************************************
 
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration;
+using System.Linq;
+using System.Text;
 using GSF.Annotations;
 using GSF.Collections;
 using GSF.Configuration;
 using GSF.Data;
 using GSF.Data.Model;
-using GSF.IO;
-using GSF.IO.Checksums;
-using GSF.Threading;
 using log4net;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Configuration;
-using System.Data.SqlClient;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 using SystemCenter.Configuration;
 using SystemCenter.Model;
 
@@ -105,10 +95,78 @@ namespace SystemCenter
 
 
         // Fields
-        private string m_dbConnectionString;
         private SystemSettings m_systemSettings;
+        private Dictionary<string, DatabaseConnectionFactory> m_connectionFactories;
+
+        // Constants
+        private const string DefaultCategory = "systemSettings";
+
         #endregion
 
+        // ToDo: Move version in XDA to somewhere where we can use same class both there and here
+        private class DatabaseConnectionFactory
+        {
+            #region [ Members ]
+
+            // Constants
+            private const string DefaultConnectionStringSettingName = "ConnectionString";
+            private const string DefaultDataProviderStringSettingName = "DataProviderString";
+
+            #endregion
+
+            #region [ Constructors ]
+
+            public DatabaseConnectionFactory(ConfigurationFile configurationFile, string settingsCategory)
+                : this (configurationFile, settingsCategory, DefaultConnectionStringSettingName, DefaultDataProviderStringSettingName) { }
+
+            public DatabaseConnectionFactory(ConfigurationFile configurationFile, string settingsCategory, string connStringSetting, string dataStringSetting)
+            {
+                ConfigurationFile = configurationFile;
+                SettingsCategory = settingsCategory;
+                ConnStringSettingName = connStringSetting;
+                DataStringSettingName = dataStringSetting;
+                LoadSettings();
+            }
+
+            #endregion
+
+            #region [ Properties ]
+
+            private ConfigurationFile ConfigurationFile { get; }
+            private string SettingsCategory { get; }
+            private string ConnStringSettingName { get; }
+            private string DataStringSettingName { get; }
+            public string ConnectionString { get; set; }
+            public string DataProviderString { get; set; }
+
+            #endregion
+
+            #region [ Methods ]
+
+            public AdoDataConnection CreateDbConnection() =>
+                new AdoDataConnection(ConnectionString, DataProviderString);
+
+            private void LoadSettings()
+            {
+                CategorizedSettingsSection categorizedSettings = ConfigurationFile.Settings;
+                CategorizedSettingsElementCollection category = categorizedSettings[SettingsCategory];
+                if (category is null)
+                    throw new ArgumentNullException($"Could not retrieve settings of category {SettingsCategory} for db connection...");
+
+                CategorizedSettingsElement connectionSetting = category[ConnStringSettingName];
+                if (connectionSetting is null)
+                    throw new ArgumentNullException($"Could not retrieve setting {ConnStringSettingName} of category {SettingsCategory} for db connection...");
+
+                CategorizedSettingsElement dataProviderSetting = category[DataStringSettingName];
+                if (dataProviderSetting is null)
+                    throw new ArgumentNullException($"Could not retrieve setting {DataStringSettingName} of category {SettingsCategory} for db connection...");
+
+                ConnectionString = connectionSetting.Value;
+                DataProviderString = dataProviderSetting.Value;
+            }
+
+            #endregion
+        }
 
         #region [ Properties ]
         private bool Stopped { get; set; } = true;
@@ -142,6 +200,9 @@ namespace SystemCenter
         /// </summary>
         public void Start()
         {
+            // Create Connection factory object
+            m_connectionFactories = new Dictionary<string, DatabaseConnectionFactory>();
+
             // Get system settings from the database
             ReloadSystemSettings();
 
@@ -173,21 +234,39 @@ namespace SystemCenter
         public void ReloadSystemSettings()
         {
             ConfigurationFile configurationFile;
-            CategorizedSettingsElementCollection category;
 
             // Reload the configuration file
             configurationFile = ConfigurationFile.Current;
             configurationFile.Reload();
-            AdoDataConnection.ReloadConfigurationSettings();
 
-            // Retrieve the connection string from the config file
-            category = configurationFile.Settings["systemSettings"];
-            category.Add("ConnectionString", "Data Source=localhost; Initial Catalog=SystemCenter; Integrated Security=SSPI", "Defines the connection to the openXDA database.");
-            m_dbConnectionString = category["ConnectionString"].Value;
-            
+            // Reconstruct known connection factories
+            AdoDataConnection.ReloadConfigurationSettings();
+            foreach (string key in m_connectionFactories.Keys)
+                CreateAndAddFactory(configurationFile, key);
+
             // Load system settings from the database
             m_systemSettings = new SystemSettings(LoadSystemSettings());
+        }
 
+
+        /// <summary>
+        /// Creates a db connection to the default database, using timeout settings.
+        /// </summary>
+        public AdoDataConnection CreateDbConnection() => CreateDbConnection(DefaultCategory);
+
+        /// <summary>
+        /// Creates a db connection to the database, using timeout settings.
+        /// </summary>
+        public AdoDataConnection CreateDbConnection(string settingsCategory)
+        {
+            if (!m_connectionFactories.TryGetValue(settingsCategory, out DatabaseConnectionFactory factory))
+                factory = CreateAndAddFactory(ConfigurationFile.Current, settingsCategory);
+
+            AdoDataConnection connection = factory.CreateDbConnection();
+            if (m_systemSettings is not null)
+                connection.DefaultTimeout = m_systemSettings.DbTimeout;
+
+            return connection;
         }
 
         /// <summary>
@@ -204,14 +283,19 @@ namespace SystemCenter
             }
         }
 
+        // Adds a new connection factory given a configuration file and settings category
+        private DatabaseConnectionFactory CreateAndAddFactory(ConfigurationFile file, string category)
+        {
+            DatabaseConnectionFactory factory = new DatabaseConnectionFactory(file, category);
+            m_connectionFactories.AddOrUpdate(category, factory);
+            return factory;
+        }
 
         // Loads system settings from the database.
         private string LoadSystemSettings()
         {
-            using (AdoDataConnection connection = new AdoDataConnection(m_dbConnectionString, typeof(SqlConnection), typeof(SqlDataAdapter)))
-            {
+            using (AdoDataConnection connection = CreateDbConnection())
                 return LoadSystemSettings(connection);
-            }
         }
 
         // Loads system settings from the database.
@@ -234,7 +318,11 @@ namespace SystemCenter
             // Add the database connection string if there is not
             // already one explicitly specified in the Setting table
             if (!settings.ContainsKey("dbConnectionString"))
-                settings.Add("dbConnectionString", m_dbConnectionString);
+            {
+                if (!m_connectionFactories.TryGetValue(DefaultCategory, out DatabaseConnectionFactory factory))
+                    factory = CreateAndAddFactory(ConfigurationFile.Current, DefaultCategory);
+                settings.Add("dbConnectionString", factory.ConnectionString);
+            }
 
             // Convert dictionary to a connection string and return it
             return SystemSettings.ToConnectionString(settings);


### PR DESCRIPTION
[SC-246](https://gridprotectionalliance.atlassian.net/browse/SC-246)

---
<h4>Description</h4>  

<h6>Adding controller activator (similar to XDA's) to system center so that we can set higher timeouts in the settings. Additional steps may be needed for meter deletion.</h6>
<br />

---
<h4>How/Where to test OR Detail how it was tested</h4>  

1.   Using different settings categories on controllers was tested.
2.   Other adapter types were tested.
3.   Model Controller compatibility was tested (with [this branch](https://github.com/GridProtectionAlliance/gsf/tree/SC_ControllerActivation)).
4.   Base functionality with no changes was tested.


[SC-246]: https://gridprotectionalliance.atlassian.net/browse/SC-246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ