### PR TITLE
Update build scripts to use VS2022

### DIFF
--- a/Build/Scripts/BuildBeta.bat
+++ b/Build/Scripts/BuildBeta.bat
@@ -23,5 +23,5 @@ SetLocal
 
 IF NOT "%1" == "" SET logflag=/l:FileLogger,Microsoft.Build.Engine;logfile=%1
 
-ECHO BuildBeta: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe SystemCenter.buildproj /p:ForceBuild=true %logflag%
-"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" SystemCenter.buildproj /p:ForceBuild=true %logFlag%
+ECHO BuildBeta: C:\Program Files\Microsoft Visual Studio\2022\Community\MsBuild\Current\Bin\MSBuild.exe SystemCenter.buildproj /p:ForceBuild=true %logflag%
+"C:\Program Files\Microsoft Visual Studio\2022\Community\MsBuild\Current\Bin\MSBuild.exe" SystemCenter.buildproj /p:ForceBuild=true %logFlag%

--- a/Build/Scripts/BuildNightly.bat
+++ b/Build/Scripts/BuildNightly.bat
@@ -23,5 +23,5 @@ SetLocal
 
 IF NOT "%1" == "" SET logflag=/l:FileLogger,Microsoft.Build.Engine;logfile=%1
 
-ECHO BuildNightly: C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe SystemCenter.buildproj /p:ForceBuild=false %logflag%
-"C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" SystemCenter.buildproj /p:ForceBuild=false %logFlag%
+ECHO BuildNightly: C:\Program Files\Microsoft Visual Studio\2022\Community\MsBuild\Current\Bin\MSBuild.exe SystemCenter.buildproj /p:ForceBuild=false %logflag%
+"C:\Program Files\Microsoft Visual Studio\2022\Community\MsBuild\Current\Bin\MSBuild.exe" SystemCenter.buildproj /p:ForceBuild=false %logFlag%


### PR DESCRIPTION
Nightly builds have been failing ever since #745 because that PR uses newer C# language features that aren't available in VS2019.