### PR TITLE
Sc 383 email timeline plot interactions do not function

### DIFF
--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -148,6 +148,7 @@ const SentEmailTimeline = (props: IProps) => {
                                 Tmin={Math.min(...timeline.map((i) => moment(i.Start).valueOf())) - 3600000}
                                 Tmax={Math.max(...timeline?.map((i) => moment(i.End ?? i.Start).valueOf())) + 3600000}
                                 onSelect={handlePlotOnSelect}
+                                onTDomainChange={(t) => setTimeframe(t) }
                             >
                                 {timeline.map((item, i) => {
                                     return (

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -110,6 +110,10 @@ const SentEmailTimeline = (props: IProps) => {
     }
 
     const handlePlotOnSelect = React.useCallback((x) => {
+        if (timeframe[0] == null || timeframe[1] == null) {
+            setSelectedID(null)
+            return
+        }
         const foundDuration = timeline.find(item => moment(item.Start).valueOf() <= x && x <= (moment(item.End ?? item.Start).valueOf()))
         if (foundDuration != null) {
             setSelectedID(foundDuration.ID);

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -109,6 +109,21 @@ const SentEmailTimeline = (props: IProps) => {
        setTimeframe(SetWithThresholds(timelineItem))
     }
 
+    const handlePlotOnSelect = (x) => {
+        const foundDuration = timeline.find(item => moment(item.Start).valueOf() <= x && x <= (moment(item.End ?? item.Start).valueOf()))
+        if (foundDuration != null) {
+            setSelectedID(foundDuration.ID);
+            return
+        }
+        const buffer = (timeframe[1] - timeframe[0]) / 1000
+        const foundTimestamp = timeline.find(item => moment(item.Start).valueOf() - buffer <= x && x <= moment(item.Start).valueOf() + buffer)
+        if (foundTimestamp) {
+            setSelectedID(foundTimestamp.ID);
+            return
+        }
+        setSelectedID(null)
+    }
+
     return (
         <>
             {state !== 'idle' ? <></> :
@@ -132,6 +147,7 @@ const SentEmailTimeline = (props: IProps) => {
                                 hideYAxis={true}
                                 Tmin={Math.min(...timeline.map((i) => moment(i.Start).valueOf())) - 3600000}
                                 Tmax={Math.max(...timeline?.map((i) => moment(i.End ?? i.Start).valueOf())) + 3600000}
+                                onSelect={handlePlotOnSelect}
                             >
                                 {timeline.map((item, i) => {
                                     return (

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -109,7 +109,7 @@ const SentEmailTimeline = (props: IProps) => {
        setTimeframe(SetWithThresholds(timelineItem))
     }
 
-    const handlePlotOnSelect = (x) => {
+    const handlePlotOnSelect = React.useCallback((x) => {
         const foundDuration = timeline.find(item => moment(item.Start).valueOf() <= x && x <= (moment(item.End ?? item.Start).valueOf()))
         if (foundDuration != null) {
             setSelectedID(foundDuration.ID);
@@ -122,7 +122,7 @@ const SentEmailTimeline = (props: IProps) => {
             return
         }
         setSelectedID(null)
-    }
+    },[timeline, timeframe])
 
     return (
         <>

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -119,7 +119,7 @@ const SentEmailTimeline = (props: IProps) => {
             setSelectedID(foundDuration.ID);
             return
         }
-        const buffer = (timeframe[1] - timeframe[0]) / 1000
+        const buffer = (timeframe[1] - timeframe[0]) / 800
         const foundTimestamp = timeline.find(item => moment(item.Start).valueOf() - buffer <= x && x <= moment(item.Start).valueOf() + buffer)
         if (foundTimestamp) {
             setSelectedID(foundTimestamp.ID);

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -152,7 +152,7 @@ const SentEmailTimeline = (props: IProps) => {
                                 Tmin={Math.min(...timeline.map((i) => moment(i.Start).valueOf())) - 3600000}
                                 Tmax={Math.max(...timeline?.map((i) => moment(i.End ?? i.Start).valueOf())) + 3600000}
                                 onSelect={handlePlotOnSelect}
-                                onTDomainChange={(t) => setTimeframe(t) }
+                                onTDomainChange={setTimeframe}
                             >
                                 {timeline.map((item, i) => {
                                     return (

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -130,7 +130,6 @@ const SentEmailTimeline = (props: IProps) => {
                                 yDomain={'AutoValue'}
                                 showDateOnTimeAxis={true}
                                 hideYAxis={true}
-                                xZoom={false}
                                 Tmin={Math.min(...timeline.map((i) => moment(i.Start).valueOf())) - 3600000}
                                 Tmax={Math.max(...timeline?.map((i) => moment(i.End ?? i.Start).valueOf())) + 3600000}
                             >

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -131,7 +131,8 @@ const SentEmailTimeline = (props: IProps) => {
                                 showDateOnTimeAxis={true}
                                 hideYAxis={true}
                                 xZoom={false}
-                                
+                                Tmin={Math.min(...timeline.map((i) => moment(i.Start).valueOf())) - 3600000}
+                                Tmax={Math.max(...timeline?.map((i) => moment(i.End ?? i.Start).valueOf())) + 3600000}
                             >
                                 {timeline.map((item, i) => {
                                     return (

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -22,12 +22,10 @@
 //******************************************************************************************************
 
 import * as React from 'react'
-import { SentEmail } from '../global'
 import * as $ from 'jquery'
 import { Application } from '@gpa-gemstone/application-typings'
 import { Table, Column } from '@gpa-gemstone/react-table'
 import moment from 'moment';
-import { Modal } from '@gpa-gemstone/react-interactive'
 import { Pill, Plot, VerticalMarker } from '@gpa-gemstone/react-graph'
 
 interface TimelineItem {

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EmailTypes/SentEmailTimeline.tsx
@@ -61,6 +61,9 @@ const SentEmailTimeline = (props: IProps) => {
 
     const tblData = React.useMemo(() => ToTimestamps(timeline), [timeline])
 
+    const tMin = React.useMemo(() => { return Math.min(...timeline.map((i) => moment(i.Start).valueOf())) - 3600000 }, [timeline])
+    const tMax = React.useMemo(() => { return Math.max(...timeline?.map((i) => moment(i.End ?? i.Start).valueOf())) + 3600000 }, [timeline])
+
     React.useEffect(() => {
         if (props.SentEmailID == null) return;
         let handle = getTimeline();
@@ -149,8 +152,8 @@ const SentEmailTimeline = (props: IProps) => {
                                 yDomain={'AutoValue'}
                                 showDateOnTimeAxis={true}
                                 hideYAxis={true}
-                                Tmin={Math.min(...timeline.map((i) => moment(i.Start).valueOf())) - 3600000}
-                                Tmax={Math.max(...timeline?.map((i) => moment(i.End ?? i.Start).valueOf())) + 3600000}
+                                Tmin={tMin}
+                                Tmax={tMax}
                                 onSelect={handlePlotOnSelect}
                                 onTDomainChange={setTimeframe}
                             >


### PR DESCRIPTION
<h4>Jira Issue(s)</h4>  

SC-383

<br />

---
<h4>Description</h4>  

Plot properties in the SentEmailTimeline are adjusted to allow for zooming along the X axis and the selection of timeline events by Plot element. 
<br />

---
<h4>How/Where to test OR Detail how it was tested</h4>  


1.  Select Event Notifications from the sidebar.
2.  Select an Email Type from the Email Type table.
3.  Navigate to the history tab.
4. Verify that x-zooming is allowed.
5. Verify that clicking a plot element with the selector selects the cooresponding timeline event.
