### PR TITLE
Sc 394 open mic daily statistics page sometimes has meter as undefined in endpoint

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
@@ -430,17 +430,17 @@ const DeviceHealthReport: Application.Types.iByComponent = (props) => {
                             Content={({ item, field, style }) => {
                                 if (item[field] == 'Error') {
                                     style.backgroundColor = 'palevioletred';
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=openmic&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=mimd&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
                                 }
                                 else if (item[field] == 'Warning') {
                                     style.backgroundColor = 'antiquewhite';
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=openmic&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.Warning Color="var(--warning)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=mimd&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.Warning Color="var(--warning)" /></a>;
                                 }
                                 else if (item.LastGood == null && item.MICBadDays == null) {
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=openmic&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.QuestionMark Color="var(--secondary)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=mimd&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.QuestionMark Color="var(--secondary)" /></a>;
                                 }
                                 else
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=openmic&OpenMICAcronym=${item.OpenMIC}`} target='_blank'><ReactIcons.CheckMark Color="var(--success)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=mimd&OpenMICAcronym=${item.OpenMIC}`} target='_blank'><ReactIcons.CheckMark Color="var(--success)" /></a>;
                             }}
                         > miMD
                         </Column>
@@ -473,7 +473,7 @@ const DeviceHealthReport: Application.Types.iByComponent = (props) => {
                             Content={({ item, field, style }) => {
                                 if (item.DQStatus == 'Error') {
                                     style.backgroundColor = 'palevioletred';
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=dq&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
                                 }
                                 else if (item.DQStatus == 'Warning') {
                                     style.backgroundColor = 'antiquewhite';

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
@@ -333,7 +333,7 @@ const DeviceHealthReport: Application.Types.iByComponent = (props) => {
                                 if (moment().diff(moment(item[field]), 'hours') > 4) className = 'info';
                                 if (moment().diff(moment(item[field]), 'hours') > 24) className = 'warning';
                                 else if (moment().diff(moment(item[field]), 'days') > 7) className = 'danger';
-                                return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=openmic`} target='_blank'>
+                                return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=openmic&OpenMICAcronym=${item.OpenMIC}`} target='_blank'>
                                     <span className={`badge badge-pill badge-${className}`}>{moment(item[field]).format('MM/DD/YYYY hh:mm')}</span></a>
                             }}
                         > Last Succ Conn

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
@@ -453,14 +453,14 @@ const DeviceHealthReport: Application.Types.iByComponent = (props) => {
                             Content={({ item, field, style }) => {
                                 if (item[field] == 'Error') {
                                     style.backgroundColor = 'palevioletred';
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
                                 }
                                 else if (item[field] == 'Warning') {
                                     style.backgroundColor = 'antiquewhite';
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda`} target='_blank' ><ReactIcons.Warning Color="var(--warning)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.Warning Color="var(--warning)" /></a>;
                                 }
                                 else
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda`} target='_blank'><ReactIcons.CheckMark Color="var(--success)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda&OpenMICAcronym=${item.OpenMIC}`} target='_blank'><ReactIcons.CheckMark Color="var(--success)" /></a>;
                             }}
                         > XDA
                         </Column>
@@ -473,14 +473,14 @@ const DeviceHealthReport: Application.Types.iByComponent = (props) => {
                             Content={({ item, field, style }) => {
                                 if (item.DQStatus == 'Error') {
                                     style.backgroundColor = 'palevioletred';
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=xda&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.CrossMark Color="var(--danger)" /></a>;
                                 }
                                 else if (item.DQStatus == 'Warning') {
                                     style.backgroundColor = 'antiquewhite';
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=dq`} target='_blank' ><ReactIcons.Warning Color="var(--warning)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=dq&OpenMICAcronym=${item.OpenMIC}`} target='_blank' ><ReactIcons.Warning Color="var(--warning)" /></a>;
                                 }
                                 else
-                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=dq`} target='_blank'><ReactIcons.CheckMark Color="var(--success)" /></a>;
+                                    return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=dq&OpenMICAcronym=${item.OpenMIC}`} target='_blank'><ReactIcons.CheckMark Color="var(--success)" /></a>;
                             }}
                         > DQ
                         </Column>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceIssuesPage/DeviceIssuesPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceIssuesPage/DeviceIssuesPage.tsx
@@ -46,8 +46,6 @@ function DeviceIssuesPage(props: IProps) {
 
     }, [props.MeterID]);
 
-    React.useEffect(() => { }, [])
-
     function getMeter(): JQuery.jqXHR<OpenXDA.Types.Meter> {
         if (props.MeterID == undefined) return null;
         return $.ajax({


### PR DESCRIPTION
<h4>Jira Issue(s)</h4>  

*<h6>SC-394</h6>*

<br />

---
<h4>Description</h4>  

*<h6>Include openMIC acronym in any link to Device Issues</h6>*  
<br />

---
<h4>How/Where to test OR Detail how it was tested</h4>  

1.   Navigate to Device Health Report in the sidebar.
2.  Select either the XDA or DQ status column to be taken to the Device Issues Page.
3.  Verify that the API request sent when selecting the openMIC Issues tab includes the openMIC acronym, which is 'null' if non-existent rather than 'undefined.'