### PR TITLE
correct last successful connection to use 24 hour time

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/DeviceHealthReport/DeviceHealthReport.tsx
@@ -336,7 +336,7 @@ const DeviceHealthReport: Application.Types.iByComponent = (props) => {
                                 if (moment().diff(moment(item[field]), 'hours') > 24) className = 'warning';
                                 else if (moment().diff(moment(item[field]), 'days') > 7) className = 'danger';
                                 return <a href={`${homePath}index.cshtml?name=DeviceIssuesPage&MeterID=${item.ID}&Tab=openmic&OpenMICAcronym=${item.OpenMIC}`} target='_blank'>
-                                    <span className={`badge badge-pill badge-${className}`}>{moment(item[field]).format('MM/DD/YYYY hh:mm')}</span></a>
+                                    <span className={`badge badge-pill badge-${className}`}>{moment(item[field]).format('MM/DD/YYYY HH:mm')}</span></a>
                             }}
                         > Last Succ Conn
                         </Column>


### PR DESCRIPTION
fix datetime formatting error that resulted in 12-hour time being used for the Last Successful Connection column of the Device Health Report table

---
**Jira Work Item(s)**

- SC-400