### PR TITLE
Sc 406 meter details assets table custom column selection clears

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
@@ -148,6 +148,7 @@ const MeterAssetWindow = (props: IProps) => {
                 <div className="card-body" style={{ paddingBottom: 0,  display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
                     <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: 'column' }}>
                         <ConfigurableTable<OpenXDA.Types.MeterAsset>
+                            LocalStorageKey="MeterAssetConfigTable"
                             TableClass="table table-hover"
                             Data={data}
                             SortKey={sortKey}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/VirtualChannelModal.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/VirtualChannelModal.tsx
@@ -209,7 +209,7 @@ export default function VirtualChannelModal(props: IProps) {
                 <div className='row' style={{height: '50%', overflowY: 'auto'}}>
                     <div className={'col-12 h-100 px-0'}>
                         <ConfigurableTable<OpenXDA.Types.Channel>
-                            // LocalStorageKey='ChannelPageConfigTable'
+                            LocalStorageKey='ChannelPageConfigTable'
                             Data={props.CurrentChannels}
                             SortKey={props.SortKey}
                             Ascending={props.Ascending}


### PR DESCRIPTION
Adds local storage for configurable tables, specifically the Asset table in Meter Details and the Virtual Channel table in the New Meter Wizard.
---
**Jira Work Item(s)**

- SC 406
