### PR TITLE
SC-408 Node Connections helper functions

### DIFF
--- a/Source/Applications/SystemCenter/SystemCenter.csproj
+++ b/Source/Applications/SystemCenter/SystemCenter.csproj
@@ -346,6 +346,7 @@
     <Compile Include="WebClients\HIDSClient.cs" />
     <Compile Include="WebClients\HttpClient.cs" />
     <Compile Include="WebClients\XDANodeClient.cs" />
+    <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\DataOperationFailureTable.tsx" />
     <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\FilesProcessed.tsx" />
   </ItemGroup>
   <ItemGroup>
@@ -555,6 +556,8 @@
     <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AdditionalFields\ByAdditionalField.tsx" />
     <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\ConsoleWindow.tsx" />
     <Content Include="wwwroot\Scripts\TSX\SystemCenter\LineSegment\ByLineSegment.tsx" />
+    <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\FilesProcessedGraph.tsx" />
+    <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\FilesProcessedTable.tsx" />
     <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\NodeConnections.tsx" />
     <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\NodeDetails.tsx" />
     <TypeScriptCompile Include="wwwroot\Scripts\TSX\SystemCenter\AppHost\NodeHealth.tsx" />

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
@@ -44,151 +44,70 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
         setStatus('loading');
         switch (props.ApplicationType) {
             case 'SystemCenter':
-                testDBs()
-                testFAWG()
-                testPQI()
-                break;
-            case 'XDA':
-                testRemoteXDAs()
-                testSCADA()
-                testStructureCrawler()
-                break;
-            default:
-                break;
-        }
-    }, [props.ApplicationName])
-
-
-    function testDBs() {
-        const h = $.ajax({
-            type: "POST",
-            url: `${homePath}api/SystemCenter/ExternalDatabases/TestAllConnections`,
-            contentType: "application/json; charset=utf-8",
-            dataType: 'json',
-            cache: false,
-            async: true
-        });
-
-        h.done((statuses: INamedStatusItem[]) => {
+                const dbs = testDBs()
+                dbs.done((statuses: INamedStatusItem[]) => {
             setExtDBStatus(statuses)
-        }).fail((d) => {
+                }).fail(() => {
             setExtDBStatus([])
         })
 
-
-        return function cleanup() {
-            if (h.abort != null)
-                h.abort();
-        }
-    }
-
-    function testRemoteXDAs() {
-        const h = $.ajax({
-            type: "GET",
-            url: `${homePath}api/OpenXDA/remoteXDAInstance/RemoteConnectionStatus/${props.Properties.find(prop => prop.Name === "ID").Value}`,
-            contentType: "application/json; charset=utf-8",
-            dataType: 'json',
-            cache: false,
-            async: true
-        });
-
-        h.done((statuses: INamedStatusItem[]) => {
-            setRemoteXDAStatus(statuses)
+                const fawg = testFAWG()
+                fawg.done((d: SC.StatusItem) => {
+                    setFawgStatus({ Status: d.Status, Name: "FAWG", Details: d.Details })
         }).fail(() => {
-            setRemoteXDAStatus([])
+                    setFawgStatus({ Status: 'Error', Name: 'FAWG', Details: [{ Status: "Error", Description: "Errors occurred in retrieving FAWG connection status." }] })
         })
-        return function cleanup() {
-            if (h.abort != null)
-                h.abort();
-        }
-    }
 
-    function testFAWG() {
-        const h = $.ajax({
-            type: "POST",
-            url: `${homePath}api/LineSegmentWizard/TestConnection`,
-            contentType: "application/json; charset=utf-8",
-            dataType: 'json',
-            cache: false,
-            async: true
-        });
-
-        h.done((d: SC.StatusItem) => {
-            setFawgStatus({Status: d.Status, Name: "FAWG", Details: d.Details})
+                const pqi = testPQI()
+                pqi.done((d: SC.StatusItem) => {
+                    setPQIStatus({ Status: d.Status, Name: "PQI", Details: d.Details })
         }).fail(() => {
-            setFawgStatus({ Status: 'Error', Name: 'FAWG', Details: [{ Status: "Error", Description: "Errors occurred in retrieving FAWG connection status." }] })
+                    setPQIStatus({ Status: 'Error', Name: 'PQI', Details: [{ Status: "Error", Description: "Errors occurred in retrieving PQI connection status." }] })
         })
 
         return function cleanup() {
-            if (h.abort != null)
-                h.abort();
-        }
+                    if (dbs.abort != null)
+                        dbs.abort();
+                    if (fawg.abort != null)
+                        fawg.abort()
+                    if (pqi.abort != null)
+                        pqi.abort()
     }
 
-    function testPQI() {
-        const h = $.ajax({
-            type: "GET",
-            url: `${homePath}api/SystemCenter/PQI/Test`,
-            contentType: "application/json; charset=utf-8",
-            dataType: 'json',
-            cache: false,
-            async: true
-        });
-
-        h.done((d: SC.StatusItem) => {
-            setPQIStatus({Status: d.Status, Name: "PQI", Details: d.Details})
+            case 'XDA':
+                const rxdas = testRemoteXDAs(props.Properties)
+                rxdas.done((statuses: INamedStatusItem[]) => {
+                    setRemoteXDAStatus(statuses)
         }).fail(() => {
-            setPQIStatus({ Status: 'Error', Name: 'PQI', Details: [{ Status: "Error", Description: "Errors occurred in retrieving PQI connection status." }] })
+                    setRemoteXDAStatus([])
         })
 
-        return function cleanup() {
-            if (h.abort != null)
-                h.abort();
-        }
-    }
-    function testSCADA() {
-        const h = $.ajax({
-            type: "GET",
-            url: `${homePath}api/OpenXDA/ScadaHealth`,
-            contentType: "application/json; charset=utf-8",
-            dataType: 'json',
-            cache: false,
-            async: true
-        });
-
-        h.done((d: SC.StatusItem) => {
-            setSCADAStatus({ Status: d.Status, Name: 'SCADA Resource', Details: d.Details})
+                const scada = testSCADA()
+                scada.done((d: SC.StatusItem) => {
+                    setSCADAStatus({ Status: d.Status, Name: 'SCADA Resource', Details: d.Details })
         }).fail(() => {
             setSCADAStatus({ Status: 'Error', Name: 'SCADA Resource', Details: [{ Status: "Error", Description: "Errors occurred in retrieving SCADA Resource connection status." }] })
         })
 
-        return function cleanup() {
-            if (h.abort != null)
-                h.abort();
-        }
-    }
-
-    function testStructureCrawler() {
-        const h = $.ajax({
-            type: "GET",
-            url: `${homePath}api/OpenXDA/StructureCrawlerHealth`,
-            contentType: "application/json; charset=utf-8",
-            dataType: 'json',
-            cache: false,
-            async: true
-        });
-
-        h.done((d: SC.StatusItem) => {
-            setStructureCrawlerStatus({ Status: d.Status, Name: "Structure Crawler", Details: d.Details})
+                const crawler = testStructureCrawler()
+                crawler.done((d: SC.StatusItem) => {
+                    setStructureCrawlerStatus({ Status: d.Status, Name: "Structure Crawler", Details: d.Details })
         }).fail(() => {
             setStructureCrawlerStatus({ Status: 'Error', Name: 'Structure Crawler', Details: [{ Status: "Error", Description: "Errors occurred in retrieving Structure Crawler connection status." }] })
         })
 
         return function cleanup() {
-            if (h.abort != null)
-                h.abort();
+                    if (rxdas.abort != null)
+                        rxdas.abort()
+                    if (scada.abort != null)
+                        scada.abort()
+                    if (crawler.abort != null)
+                        crawler.abort()
         }
+            default:
+                return;
     }
+    }, [props.ApplicationName])
 
     return (
         props.ApplicationType === 'SystemCenter' ?
@@ -242,3 +161,69 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
 }
 
 export default NodeConnections;
+
+
+function testDBs() {
+    return $.ajax({
+        type: "POST",
+        url: `${homePath}api/SystemCenter/ExternalDatabases/TestAllConnections`,
+        contentType: "application/json; charset=utf-8",
+        dataType: 'json',
+        cache: false,
+        async: true
+    });
+}
+
+function testFAWG() {
+    return $.ajax({
+        type: "POST",
+        url: `${homePath}api/LineSegmentWizard/TestConnection`,
+        contentType: "application/json; charset=utf-8",
+        dataType: 'json',
+        cache: false,
+        async: true
+    });
+}
+
+function testPQI() {
+    return $.ajax({
+        type: "GET",
+        url: `${homePath}api/SystemCenter/PQI/Test`,
+        contentType: "application/json; charset=utf-8",
+        dataType: 'json',
+        cache: false,
+        async: true
+    });
+}
+function testRemoteXDAs(properties: { Name: string, Value: string }[]) {
+    return $.ajax({
+        type: "GET",
+        url: `${homePath}api/OpenXDA/remoteXDAInstance/RemoteConnectionStatus/${properties.find(prop => prop.Name === "ID").Value}`,
+        contentType: "application/json; charset=utf-8",
+        dataType: 'json',
+        cache: false,
+        async: true
+    });
+}
+
+function testSCADA() {
+    return $.ajax({
+        type: "GET",
+        url: `${homePath}api/OpenXDA/ScadaHealth`,
+        contentType: "application/json; charset=utf-8",
+        dataType: 'json',
+        cache: false,
+        async: true
+    });
+}
+
+function testStructureCrawler() {
+    return $.ajax({
+        type: "GET",
+        url: `${homePath}api/OpenXDA/StructureCrawlerHealth`,
+        contentType: "application/json; charset=utf-8",
+        dataType: 'json',
+        cache: false,
+        async: true
+    });
+}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
@@ -25,13 +25,11 @@
 //******************************************************************************************************
 
 import * as React from 'react'
-import { Application } from '@gpa-gemstone/application-typings'
 import { SystemCenter as SC } from '../global'
 import StatusGroup from './StatusGroup'
 import { INamedStatusItem } from './StatusItem'
 
 const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.ApplicationType, Properties: { Name: string, Value: string }[] }) => {
-    const [status, setStatus] = React.useState<Application.Types.Status>('uninitiated');
     const [extDBStatus, setExtDBStatus] = React.useState<INamedStatusItem[]>([{ Name: "Loading...", Status: "Loading", Details: [] }]);
     const [remoteXDAStatus, setRemoteXDAStatus] = React.useState<INamedStatusItem[]>([{ Name: "Loading...", Status: "Loading", Details: [] }]);
     const [hoveredItem, setHoveredItem] = React.useState<string>(null)
@@ -41,7 +39,6 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
     const [structureCrawlerStatus, setStructureCrawlerStatus] = React.useState<INamedStatusItem>({ Name: "Structure Crawler", Status: "Loading", Details: []})
 
     React.useEffect(() => {
-        setStatus('loading');
         switch (props.ApplicationType) {
             case 'SystemCenter':
                 const dbs = testDBs()
@@ -116,7 +113,6 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                     <div className="col-6 h-100">
                     <StatusGroup
                         StatusItems={extDBStatus}
-                        Status={status}
                         HoveredItem={hoveredItem}
                         SetHoveredItem={setHoveredItem}
                         Name="External Database Connections"
@@ -126,7 +122,6 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                 <div className={`col-${extDBStatus.length == 0 ? 12 : 6} h-100`}>
                     <StatusGroup
                         StatusItems={[fawgStatus, PQIStatus]}
-                        Status={status}
                         HoveredItem={hoveredItem}
                         SetHoveredItem={setHoveredItem}
                         Name="Other Connections"
@@ -139,7 +134,6 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                         <div className="col-6 h-100">
                         <StatusGroup
                             StatusItems={remoteXDAStatus}
-                            Status={status}
                             HoveredItem={hoveredItem}
                             SetHoveredItem={setHoveredItem}
                             Name="Remote openXDA Connections"
@@ -149,7 +143,6 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                     <div className={`col-${remoteXDAStatus.length == 0 ? 12 : 6} h-100`}>
                         <StatusGroup
                             StatusItems={[SCADAStatus, structureCrawlerStatus]}
-                            Status={status}
                             HoveredItem={hoveredItem}
                             SetHoveredItem={setHoveredItem}
                             Name="Other Connections"

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
@@ -36,74 +36,74 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
     const [fawgStatus, setFawgStatus] = React.useState<INamedStatusItem>({ Name: "FAWG", Status: "Loading", Details: [] })
     const [PQIStatus, setPQIStatus] = React.useState<INamedStatusItem>({ Name: "PQI", Status: "Loading", Details: [] })
     const [SCADAStatus, setSCADAStatus] = React.useState<INamedStatusItem>({ Name: "SCADA Resource", Status: "Loading", Details: [] })
-    const [structureCrawlerStatus, setStructureCrawlerStatus] = React.useState<INamedStatusItem>({ Name: "Structure Crawler", Status: "Loading", Details: []})
+    const [structureCrawlerStatus, setStructureCrawlerStatus] = React.useState<INamedStatusItem>({ Name: "Structure Crawler", Status: "Loading", Details: [] })
 
     React.useEffect(() => {
         switch (props.ApplicationType) {
             case 'SystemCenter':
                 const dbs = testDBs()
                 dbs.done((statuses: INamedStatusItem[]) => {
-            setExtDBStatus(statuses)
+                    setExtDBStatus(statuses)
                 }).fail(() => {
-            setExtDBStatus([])
-        })
+                    setExtDBStatus([])
+                })
 
                 const fawg = testFAWG()
                 fawg.done((d: SC.StatusItem) => {
                     setFawgStatus({ Status: d.Status, Name: "FAWG", Details: d.Details })
-        }).fail(() => {
+                }).fail(() => {
                     setFawgStatus({ Status: 'Error', Name: 'FAWG', Details: [{ Status: "Error", Description: "Errors occurred in retrieving FAWG connection status." }] })
-        })
+                })
 
                 const pqi = testPQI()
                 pqi.done((d: SC.StatusItem) => {
                     setPQIStatus({ Status: d.Status, Name: "PQI", Details: d.Details })
-        }).fail(() => {
+                }).fail(() => {
                     setPQIStatus({ Status: 'Error', Name: 'PQI', Details: [{ Status: "Error", Description: "Errors occurred in retrieving PQI connection status." }] })
-        })
+                })
 
-        return function cleanup() {
+                return function cleanup() {
                     if (dbs.abort != null)
                         dbs.abort();
                     if (fawg.abort != null)
                         fawg.abort()
                     if (pqi.abort != null)
                         pqi.abort()
-    }
+                }
 
             case 'XDA':
                 const rxdas = testRemoteXDAs(props.Properties)
                 rxdas.done((statuses: INamedStatusItem[]) => {
                     setRemoteXDAStatus(statuses)
-        }).fail(() => {
+                }).fail(() => {
                     setRemoteXDAStatus([])
-        })
+                })
 
                 const scada = testSCADA()
                 scada.done((d: SC.StatusItem) => {
                     setSCADAStatus({ Status: d.Status, Name: 'SCADA Resource', Details: d.Details })
-        }).fail(() => {
-            setSCADAStatus({ Status: 'Error', Name: 'SCADA Resource', Details: [{ Status: "Error", Description: "Errors occurred in retrieving SCADA Resource connection status." }] })
-        })
+                }).fail(() => {
+                    setSCADAStatus({ Status: 'Error', Name: 'SCADA Resource', Details: [{ Status: "Error", Description: "Errors occurred in retrieving SCADA Resource connection status." }] })
+                })
 
                 const crawler = testStructureCrawler()
                 crawler.done((d: SC.StatusItem) => {
                     setStructureCrawlerStatus({ Status: d.Status, Name: "Structure Crawler", Details: d.Details })
-        }).fail(() => {
-            setStructureCrawlerStatus({ Status: 'Error', Name: 'Structure Crawler', Details: [{ Status: "Error", Description: "Errors occurred in retrieving Structure Crawler connection status." }] })
-        })
+                }).fail(() => {
+                    setStructureCrawlerStatus({ Status: 'Error', Name: 'Structure Crawler', Details: [{ Status: "Error", Description: "Errors occurred in retrieving Structure Crawler connection status." }] })
+                })
 
-        return function cleanup() {
+                return function cleanup() {
                     if (rxdas.abort != null)
                         rxdas.abort()
                     if (scada.abort != null)
                         scada.abort()
                     if (crawler.abort != null)
                         crawler.abort()
-        }
+                }
             default:
                 return;
-    }
+        }
     }, [props.ApplicationName])
 
     return (
@@ -111,13 +111,13 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
             <div className="row h-100">
                 {extDBStatus.length == 0 ? null :
                     <div className="col-6 h-100">
-                    <StatusGroup
-                        StatusItems={extDBStatus}
-                        HoveredItem={hoveredItem}
-                        SetHoveredItem={setHoveredItem}
-                        Name="External Database Connections"
-                    />
-                </div>
+                        <StatusGroup
+                            StatusItems={extDBStatus}
+                            HoveredItem={hoveredItem}
+                            SetHoveredItem={setHoveredItem}
+                            Name="External Database Connections"
+                        />
+                    </div>
                 }
                 <div className={`col-${extDBStatus.length == 0 ? 12 : 6} h-100`}>
                     <StatusGroup
@@ -132,13 +132,13 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                 <div className="row h-100">
                     {remoteXDAStatus.length == 0 ? null :
                         <div className="col-6 h-100">
-                        <StatusGroup
-                            StatusItems={remoteXDAStatus}
-                            HoveredItem={hoveredItem}
-                            SetHoveredItem={setHoveredItem}
-                            Name="Remote openXDA Connections"
-                        />
-                    </div>
+                            <StatusGroup
+                                StatusItems={remoteXDAStatus}
+                                HoveredItem={hoveredItem}
+                                SetHoveredItem={setHoveredItem}
+                                Name="Remote openXDA Connections"
+                            />
+                        </div>
                     }
                     <div className={`col-${remoteXDAStatus.length == 0 ? 12 : 6} h-100`}>
                         <StatusGroup

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/NodeConnections.tsx
@@ -41,6 +41,7 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
     React.useEffect(() => {
         switch (props.ApplicationType) {
             case 'SystemCenter':
+                setExtDBStatus([{ Name: "Loading...", Status: "Loading", Details: [] }])
                 const dbs = testDBs()
                 dbs.done((statuses: INamedStatusItem[]) => {
                     setExtDBStatus(statuses)
@@ -48,6 +49,7 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                     setExtDBStatus([])
                 })
 
+                setFawgStatus({ Name: "FAWG", Status: "Loading", Details: [] })
                 const fawg = testFAWG()
                 fawg.done((d: SC.StatusItem) => {
                     setFawgStatus({ Status: d.Status, Name: "FAWG", Details: d.Details })
@@ -55,6 +57,7 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                     setFawgStatus({ Status: 'Error', Name: 'FAWG', Details: [{ Status: "Error", Description: "Errors occurred in retrieving FAWG connection status." }] })
                 })
 
+                setPQIStatus({ Name: "PQI", Status: "Loading", Details: [] })
                 const pqi = testPQI()
                 pqi.done((d: SC.StatusItem) => {
                     setPQIStatus({ Status: d.Status, Name: "PQI", Details: d.Details })
@@ -72,6 +75,7 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                 }
 
             case 'XDA':
+                setRemoteXDAStatus([{ Name: "Loading...", Status: "Loading", Details: [] }])
                 const rxdas = testRemoteXDAs(props.Properties)
                 rxdas.done((statuses: INamedStatusItem[]) => {
                     setRemoteXDAStatus(statuses)
@@ -79,6 +83,7 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                     setRemoteXDAStatus([])
                 })
 
+                setSCADAStatus({ Name: "SCADA Resource", Status: "Loading", Details: [] })
                 const scada = testSCADA()
                 scada.done((d: SC.StatusItem) => {
                     setSCADAStatus({ Status: d.Status, Name: 'SCADA Resource', Details: d.Details })
@@ -86,6 +91,7 @@ const NodeConnections = (props: { ApplicationName: string, ApplicationType: SC.A
                     setSCADAStatus({ Status: 'Error', Name: 'SCADA Resource', Details: [{ Status: "Error", Description: "Errors occurred in retrieving SCADA Resource connection status." }] })
                 })
 
+                setStructureCrawlerStatus({ Name: "Structure Crawler", Status: "Loading", Details: [] })
                 const crawler = testStructureCrawler()
                 crawler.done((d: SC.StatusItem) => {
                     setStructureCrawlerStatus({ Status: d.Status, Name: "Structure Crawler", Details: d.Details })

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/StatusGroup.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AppHost/StatusGroup.tsx
@@ -22,10 +22,9 @@
 //******************************************************************************************************
 
 import * as React from 'react'
-import { Application } from '@gpa-gemstone/application-typings'
 import StatusItem, { INamedStatusItem } from './StatusItem'
 
-const StatusGroup = (props: { Name: string, StatusItems: INamedStatusItem[], Status: Application.Types.Status, HoveredItem: String, SetHoveredItem: React.Dispatch<React.SetStateAction<String>> }) => {
+const StatusGroup = (props: { Name: string, StatusItems: INamedStatusItem[], HoveredItem: String, SetHoveredItem: React.Dispatch<React.SetStateAction<String>> }) => {
     return (
         <fieldset className="border h-100" style={{ padding: '10px', flex: '1 1 0%', display: 'flex', flexDirection: 'column', overflow: 'auto' }}>
             <legend className="w-auto" style={{ fontSize: 'large' }}>{`${props.Name}:`}</legend>


### PR DESCRIPTION
Restructures the helper functions which make network requests to check XDA and System Center connections, making them pure functions outside of the `NodeConnections` component which return promises, allowing the network requests to be cleaned up. Also removes the unused `Status` state.
---
**Jira Work Item(s)**

- SC-408