### PR TITLE
Sc 266 replace location with substation

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AdditionalFields/ByAdditionalField.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AdditionalFields/ByAdditionalField.tsx
@@ -191,7 +191,7 @@ const ByAdditionalField: Application.Types.iByComponent = (props) => {
                             Field={'ParentTable'}
                             HeaderStyle={{ width: 'auto' }}
                             RowStyle={{ width: 'auto' }}
-                            Content={({ item }) => item.ParentTable != '' ? item.ParentTable : 'No Associated Table' }
+                            Content={({ item }) => item.ParentTable != '' ? (item.ParentTable === 'Location' ? 'Substation' : item.ParentTable) : 'No Associated Table' }
                         > Parent Type
                         </Column>
                         <Column<SystemCenter.Types.AdditionalFieldView>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/SourceImpedanceWindow.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/SourceImpedanceWindow.tsx
@@ -143,7 +143,7 @@ function SourceImpedanceWindow(props: { ID: number }): JSX.Element {
         if (!valid('RSrc'))
             e.push('R must be a numeric value.');
         if (!valid('AssetLocationID'))
-            e.push('A valid Location must be selected.');
+            e.push('A valid Substation must be selected.');
 
         return e;
     }

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ExternalDBTableFields.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/ExternalDBTableFields.tsx
@@ -187,6 +187,7 @@ export default function ExternalDBTableFields(props: { TableName: string, ID: nu
                                                 Field={'ParentTable'}
                                                 HeaderStyle={{ width: 'auto' }}
                                                 RowStyle={{ width: 'auto' }}
+                                                Content={({ item }) => item.ParentTable != '' ? (item.ParentTable === 'Location' ? 'Substation' : item.ParentTable) : 'No Associated Table'}
                                             > ParentType
                                             </Column>
                                             <Column<SystemCenter.Types.AdditionalFieldView>

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/TableTesting/TargetTypeSelection.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/ExternalDB/TableTesting/TargetTypeSelection.tsx
@@ -31,7 +31,7 @@ interface IProps {
     SetTable: (table: string | undefined) => void;
 }
 
-const parentTableOptions = (OpenXDA.Lists.AssetTypes as string[]).concat(['Meter', 'Location', 'Customer', 'Asset']).map(name => { return { Value: name, Label: name } });
+const parentTableOptions = (OpenXDA.Lists.AssetTypes as string[]).concat(['Meter', 'Substation', 'Customer', 'Asset']).map(name => { return { Value: name, Label: name } });
 
 interface TableOptions { ShowTableSelect: boolean, TableName: string };
 
@@ -40,7 +40,7 @@ export default function TargetTypesSelection(props: IProps) {
     const [parentTable, setParentTable] = React.useState<TableOptions>({ ShowTableSelect: true, TableName: parentTableOptions[0].Value });
 
     React.useEffect(() => {
-        if (parentTable.ShowTableSelect) props.SetTable(parentTable.TableName)
+        if (parentTable.ShowTableSelect) props.SetTable(parentTable.TableName === 'Substation' ? 'Location' : parentTable.TableName)
         else props.SetTable('');
     }, [parentTable])
     // Needed to Select Record for Query

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EventFilterComponents/EventFilterButton.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EventFilterComponents/EventFilterButton.tsx
@@ -127,7 +127,7 @@ function EventFilterButton(props: IProps) {
     return (
         <>
             <button className={"btn btn-block btn-sm btn-" + (props.IDs.length > 0 ? "warning" : "primary")} style={{ marginBottom: 5 }} onClick={(evt) => { evt.preventDefault(); props.OnClick(); }} onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
-                {props.Type} {props.IDs.length > 0 ? ('(' + props.IDs.length + ')') : ''}
+                {props.Type === 'Location' ? 'Substation' : props.Type} {props.IDs.length > 0 ? ('(' + props.IDs.length + ')') : ''}
             </button>
             <div style={{ width: window.innerWidth / 3, display: hover ? 'block' : 'none', position: 'absolute', backgroundColor: '#f1f1f1', boxShadow: '0px 8px 16px 0px rgba(0,0,0,0.2)', zIndex: 1, right: 0 }} onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
                 <table className='table'>

--- a/Source/Applications/SystemCenterNotification/Scripts/TSX/EventFilterComponents/FilterSelect.tsx
+++ b/Source/Applications/SystemCenterNotification/Scripts/TSX/EventFilterComponents/FilterSelect.tsx
@@ -214,7 +214,7 @@ function FilterSelect(props: IProps) {
             }}
             Show={props.Show}
             Type={'multiple'}
-            Title={"Filter by Location"}
+            Title={"Filter by Substation"}
             GetEnum={getEnum}
             GetAddlFields={getAdditionalFields}
         >


### PR DESCRIPTION
Display 'Substation' rather than 'Location' in Additional Fields from the old `Location` parent table.
As of now, this is the only known case of 'Location' still occurring in SystemCenter.

---
**Jira Work Item(s)**

- SC-266
