### PR TITLE
Sc 422 add spare button field for bus breaker and transformer assets

### DIFF
--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -869,6 +869,7 @@ namespace SystemCenter.Controllers.OpenXDA
             bus.AssetKey = record["AssetKey"].ToString();
             bus.Description = record["Description"].ToString();
             bus.AssetName = record["AssetName"].ToString();
+            bus.Spare = record["Spare"].ToObject<bool>();
         }
 
         private void CreateGenFromJToken(Generation gen, JToken record)
@@ -965,6 +966,7 @@ namespace SystemCenter.Controllers.OpenXDA
             transformer.SecondaryWinding = record["SecondaryWinding"].ToObject<double>();
             transformer.TertiaryWinding = record["TertiaryWinding"].ToObject<double>();
             transformer.Tap = record["Tap"].ToObject<double>();
+            transformer.Spare = record["Spare"].ToObject<bool>();
         }
 
         ////Need to Override the external DB Function to return the list for all Assets

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/AssetInfo.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Asset/AssetInfo.tsx
@@ -167,6 +167,11 @@ function AssetInfoWindow(props: IProps) {
         if (asset.Description != editAsset.Description)
             result.push('Description')
 
+        if (asset.AssetType == 'Bus') {
+            if ((asset as OpenXDA.Types.Bus).Spare != (editAsset as OpenXDA.Types.Bus).Spare)
+                result.push('Spare')
+        }
+
         if (asset.AssetType == 'Breaker') {
             if ((asset as OpenXDA.Types.Breaker).ThermalRating != (editAsset as OpenXDA.Types.Breaker).ThermalRating)
                 result.push('Thermal Rating')
@@ -236,6 +241,8 @@ function AssetInfoWindow(props: IProps) {
                 result.push('Secondary Winding')
             if ((asset as OpenXDA.Types.Transformer).TertiaryWinding != (editAsset as OpenXDA.Types.Transformer).TertiaryWinding)
                 result.push('Tertiary Winding')
+            if ((asset as OpenXDA.Types.Transformer).Spare != (editAsset as OpenXDA.Types.Transformer).Spare)
+                result.push('Spare')
         }
         if (asset.AssetType == 'CapacitorBank') {
             if ((asset as OpenXDA.Types.CapBank).Fused != (editAsset as OpenXDA.Types.CapBank).Fused ||

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Breaker.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Breaker.tsx
@@ -116,16 +116,16 @@ function BreakerAttributes(props: { NewEdit: Application.Types.NewEdit, Asset: O
                     />
                     <CheckBox<OpenXDA.Types.Breaker> Record={props.Asset} Field={'AirGapResistor'} Label={'Air Gap Resistor'} Setter={props.UpdateState} Disabled={disable} />
                 </div>
-                {props.ShowSpare ? <>
-                    <div className="col-6">
-                        <CheckBox<OpenXDA.Types.Breaker> Record={props.Asset} Field={'Spare'} Label={'Use Spare Instead'} Setter={props.UpdateState} Disabled={disable} />
-                    </div>
+                <div className="col-6">
+                    <CheckBox<OpenXDA.Types.Breaker> Record={props.Asset} Field={'Spare'} Label={'Is a Spare Breaker'} Setter={props.UpdateState} Disabled={disable} />
+                </div>
+                {props.ShowSpare && props.Asset.Spare == false ? <>
                     <div className="col-12">
                         <div className="alert alert-info" role="alert">
                             <p>Spare Breakers must be assigned to the same Substation as the original Breaker.</p>
                             <p>If a Breaker does not show up in the list below, it is not assigned to the same Substation.</p>
                         </div>
-                        <div className="form-group" hidden={!props.Asset.Spare}>
+                        <div className="form-group" hidden={props.Asset.Spare}>
                             <label>Spare Breaker</label>
                             <select className="form-control" value={props.Asset.SpareBreakerID == null ? 0 : props.Asset.SpareBreakerID} onChange={(evt) => {
                                 let record: OpenXDA.Types.Breaker = _.clone(props.Asset);

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Breaker.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Breaker.tsx
@@ -117,7 +117,7 @@ function BreakerAttributes(props: { NewEdit: Application.Types.NewEdit, Asset: O
                     <CheckBox<OpenXDA.Types.Breaker> Record={props.Asset} Field={'AirGapResistor'} Label={'Air Gap Resistor'} Setter={props.UpdateState} Disabled={disable} />
                 </div>
                 <div className="col-6">
-                    <CheckBox<OpenXDA.Types.Breaker> Record={props.Asset} Field={'Spare'} Label={'Is a Spare Breaker'} Setter={props.UpdateState} Disabled={disable} />
+                    <CheckBox<OpenXDA.Types.Breaker> Record={props.Asset} Field={'Spare'} Label={'Is a Spare Breaker'} Setter={(record) => { const r = _.clone(record); if (r.Spare) { r.SpareBreakerID = null }; props.UpdateState(r) }} Disabled={disable} />
                 </div>
                 {props.ShowSpare && props.Asset.Spare == false ? <>
                     <div className="col-12">

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Bus.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Bus.tsx
@@ -22,9 +22,25 @@
 //******************************************************************************************************
 
 import * as React from 'react';
-import { Application, OpenXDA } from '@gpa-gemstone/application-typings';
+import { Application, OpenXDA } from '@gpa-gemstone/application-typings'; 
+import { CheckBox } from '@gpa-gemstone/react-forms'
+import { useAppSelector } from '../hooks';
+import { SelectRoles } from '../Store/UserSettings';
+
 function BusAttributes(props: { NewEdit: Application.Types.NewEdit, Asset: OpenXDA.Types.Bus, UpdateState: (newEditAsset: OpenXDA.Types.Bus) => void }): JSX.Element {
-    return <span>No Additional Attributes</span>;
+
+    const roles = useAppSelector(SelectRoles);
+
+    const disable = React.useMemo(() => {
+        return (
+            (props.NewEdit == 'New' && props.Asset.ID != 0) ||
+            (roles.indexOf('Administrator') < 0 && roles.indexOf('Engineer') < 0)
+        );
+    }, [props.NewEdit, props.Asset.ID, roles]);
+
+    return  <div className="col-4">
+        <CheckBox<OpenXDA.Types.Bus> Record={props.Asset} Field={'Spare'} Label={'Is a Spare Bus'} Setter={props.UpdateState} Disabled={disable} />
+    </div>
 }
 
 export default BusAttributes;

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Bus.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Bus.tsx
@@ -22,7 +22,7 @@
 //******************************************************************************************************
 
 import * as React from 'react';
-import { Application, OpenXDA } from '@gpa-gemstone/application-typings'; 
+import { Application, OpenXDA } from '@gpa-gemstone/application-typings';
 import { CheckBox } from '@gpa-gemstone/react-forms'
 import { useAppSelector } from '../hooks';
 import { SelectRoles } from '../Store/UserSettings';
@@ -38,8 +38,10 @@ function BusAttributes(props: { NewEdit: Application.Types.NewEdit, Asset: OpenX
         );
     }, [props.NewEdit, props.Asset.ID, roles]);
 
-    return  <div className="col-4">
-        <CheckBox<OpenXDA.Types.Bus> Record={props.Asset} Field={'Spare'} Label={'Is a Spare Bus'} Setter={props.UpdateState} Disabled={disable} />
+    return <div className="row">
+        <div className="col-4">
+            <CheckBox<OpenXDA.Types.Bus> Record={props.Asset} Field={'Spare'} Label={'Is a Spare Bus'} Setter={props.UpdateState} Disabled={disable} />
+        </div>
     </div>
 }
 

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Transformer.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Transformer.tsx
@@ -25,7 +25,7 @@ import * as React from 'react';
 import * as _ from 'lodash';
 import { Application, OpenXDA } from '@gpa-gemstone/application-typings';
 import { AssetAttributes } from './Asset';
-import { Input } from '@gpa-gemstone/react-forms';
+import { Input, CheckBox } from '@gpa-gemstone/react-forms';
 import { useAppSelector } from '../hooks';
 import { SelectRoles } from '../Store/UserSettings';
 
@@ -110,6 +110,9 @@ function TransformerAttributes(props: {
                 </div>
                 <div className="col-4"> 
                     <Input<OpenXDA.Types.Transformer> Record={props.Asset} Field={'TertiaryWinding'} Label={'Tertiary Winding'} Feedback={'Tertiary Winding must be a numeric value.'} Valid={valid} Setter={props.UpdateState} Disabled={disable} />
+                </div>
+                <div className="col-4">
+                    <CheckBox<OpenXDA.Types.Transformer> Record={props.Asset} Field={'Spare'} Label={'Is a Spare Transformer'} Setter={props.UpdateState} Disabled={disable} />
                 </div>
             </div>
         </>


### PR DESCRIPTION
Adds 'Is A Spare' checkboxes to Bus and Transformers assets along with logic for checking whether or not the 'Spare' field has changed and posting changes. 

Corrects 'Spare' logic in Breakers, so the checkbox is labelled correctly and the spare dropdown displays when it is unchecked.
---
**Jira Work Item(s)**

SC-422
