### PR TITLE
SC-423 Synchronize NuGet package versions with GSF and openXDA

### DIFF
--- a/Source/Applications/SystemCenter/SystemCenter.csproj
+++ b/Source/Applications/SystemCenter/SystemCenter.csproj
@@ -232,8 +232,8 @@
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.Linq" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=6.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Diagnostics.DiagnosticSource.6.0.1\lib\net461\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Diagnostics.DiagnosticSource.8.0.1\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Formats.Asn1, Version=8.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/Source/Applications/SystemCenter/Web.config
+++ b/Source/Applications/SystemCenter/Web.config
@@ -45,6 +45,14 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-8.0.0.1" newVersion="8.0.0.1" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.data>

--- a/Source/Applications/SystemCenter/packages.config
+++ b/Source/Applications/SystemCenter/packages.config
@@ -7,7 +7,7 @@
   <package id="Oracle.ManagedDataAccess" version="23.7.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.ComponentModel" version="4.3.0" targetFramework="net48" />
-  <package id="System.Diagnostics.DiagnosticSource" version="6.0.1" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" targetFramework="net48" />
   <package id="System.Formats.Asn1" version="8.0.1" targetFramework="net48" />
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />

--- a/Source/Tests/UserInterface/UserInterface.csproj
+++ b/Source/Tests/UserInterface/UserInterface.csproj
@@ -55,8 +55,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\Dependencies\NuGet\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\Dependencies\NuGet\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>

--- a/Source/Tests/UserInterface/packages.config
+++ b/Source/Tests/UserInterface/packages.config
@@ -8,6 +8,6 @@
   <package id="NUnit3TestAdapter" version="4.6.0" targetFramework="net472" />
   <package id="Selenium.Support" version="4.23.0" targetFramework="net472" />
   <package id="Selenium.WebDriver" version="4.23.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net472" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
This doesn't actually solve the issue as described in SC-423, but it does fix a couple dependency version mismatch issues.

The fix for `System.Runtime.CompilerServices.Unsafe` will need to come from a rolldown after https://github.com/GridProtectionAlliance/gsf/pull/560 is merged.