### PR TITLE
Asset fixes

### DIFF
--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -383,11 +383,11 @@ namespace SystemCenter.Controllers.OpenXDA
                         Description = asset["Description"].ToString(),
                         AssetName = asset["AssetName"].ToString(),
                         AssetTypeID = assetTypeID,
-                        R0 = asset["Detail"].Value<double?>("R0") ?? 0,
-                        X0 = asset["Detail"].Value<double?>("X0") ?? 0,
-                        R1 = asset["Detail"].Value<double?>("R1") ?? 0,
-                        X1 = asset["Detail"].Value<double?>("X1") ?? 0,
-                        Length = asset["Detail"].Value<double?>("Length") ?? 0
+                        R0 = asset["Detail"]?.Value<double?>("R0") ?? 0,
+                        X0 = asset["Detail"]?.Value<double?>("X0") ?? 0,
+                        R1 = asset["Detail"]?.Value<double?>("R1") ?? 0,
+                        X1 = asset["Detail"]?.Value<double?>("X1") ?? 0,
+                        Length = asset["Detail"]?.Value<double?>("Length") ?? 0
                     };
                     lineSegment.AssetTypeID = connection.ExecuteScalar<int>("SELECT ID FROM AssetType WHERE Name = 'LineSegment'");
 

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -914,6 +914,7 @@ namespace SystemCenter.Controllers.OpenXDA
             capBank.PosReactanceTol = record["PosReactanceTol"].ToObject<double>();
             capBank.Nparalell = record["Nparalell"].ToObject<int>();
             capBank.Nseries = record["Nseries"].ToObject<int>();
+            /**
             capBank.NSeriesGroup = record["NSeriesGroup"].ToObject<int>();
             capBank.NParalellGroup = record["NParalellGroup"].ToObject<int>();
             capBank.Fused = record["Fused"].ToObject<bool>();
@@ -924,10 +925,12 @@ namespace SystemCenter.Controllers.OpenXDA
             capBank.LVKV = record["LVKV"].ToObject<double>();
             capBank.LVNegReactanceTol = record["LVNegReactanceTol"].ToObject<double>();
             capBank.LVPosReactanceTol = record["LVPosReactanceTol"].ToObject<double>();
+            */
             capBank.LowerXFRRatio = record["LowerXFRRatio"].ToObject<double>();
             capBank.Nshorted = record["Nshorted"].ToObject<double>();
             capBank.BlownFuses = record["BlownFuses"].ToObject<int>();
             capBank.BlownGroups = record["BlownGroups"].ToObject<int>();
+            /**
             capBank.ShortedGroups = record["ShortedGroups"].ToObject<double>();
             capBank.NLowerGroups = record["NLowerGroups"].ToObject<int>();
 
@@ -936,6 +939,7 @@ namespace SystemCenter.Controllers.OpenXDA
             capBank.Sh = record["Sh"].ToObject<double>();
             capBank.Rv = record["Rv"].ToObject<double>();
             capBank.Rh = record["Rh"].ToObject<double>();
+            */
             capBank.Compensated = record["Compensated"].ToObject<bool>();
 
         }

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -382,7 +382,12 @@ namespace SystemCenter.Controllers.OpenXDA
                         AssetKey = asset["AssetKey"].ToString() + "LineSegment",
                         Description = asset["Description"].ToString(),
                         AssetName = asset["AssetName"].ToString(),
-                        AssetTypeID = assetTypeID
+                        AssetTypeID = assetTypeID,
+                        R0 = asset["Detail"].Value<double?>("R0") ?? 0,
+                        X0 = asset["Detail"].Value<double?>("X0") ?? 0,
+                        R1 = asset["Detail"].Value<double?>("R1") ?? 0,
+                        X1 = asset["Detail"].Value<double?>("X1") ?? 0,
+                        Length = asset["Detail"].Value<double?>("Length") ?? 0
                     };
                     lineSegment.AssetTypeID = connection.ExecuteScalar<int>("SELECT ID FROM AssetType WHERE Name = 'LineSegment'");
 

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -478,6 +478,12 @@ namespace SystemCenter.Controllers.OpenXDA
                     CreateTransformerFromJToken(transformer, asset);
                     new TableOperations<Transformer>(connection).AddNewRecord(transformer);
                 }
+                else if (assetType == "DER")
+                {
+                    DER der = new DER();
+                    CreateDERFromJToken(der, asset);
+                    new TableOperations<DER>(connection).AddNewRecord(der);
+                }
                 else
                 {
                     Asset newAsset = new Asset();
@@ -967,6 +973,15 @@ namespace SystemCenter.Controllers.OpenXDA
             transformer.TertiaryWinding = record["TertiaryWinding"].ToObject<double>();
             transformer.Tap = record["Tap"].ToObject<double>();
             transformer.Spare = record["Spare"].ToObject<bool>();
+        }
+        private void CreateDERFromJToken(DER der, JToken record)
+        {
+            der.VoltageKV = record["VoltageKV"].ToObject<double>();
+            der.AssetKey = record["AssetKey"].ToString();
+            der.Description = record["Description"].ToString();
+            der.AssetName = record["AssetName"].ToString();
+            der.FullRatedOutputCurrent = record["FullRatedOutputCurrent"].ToObject<double>();
+            der.VoltageLevel = record["VoltageLevel"].ToString();
         }
 
         ////Need to Override the external DB Function to return the list for all Assets

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -966,10 +966,10 @@ namespace SystemCenter.Controllers.OpenXDA
             transformer.ThermalRating = record["ThermalRating"].ToObject<double>();
             transformer.PrimaryVoltageKV = record["PrimaryVoltageKV"].ToObject<double>();
             transformer.SecondaryVoltageKV = record["SecondaryVoltageKV"].ToObject<double>();
-            transformer.TertiaryVoltageKV = record["TertiaryVoltageKV"].ToObject<double>();
+            // transformer.TertiaryVoltageKV = record["TertiaryVoltageKV"].ToObject<double>();
             transformer.PrimaryWinding = record["PrimaryWinding"].ToObject<double>();
             transformer.SecondaryWinding = record["SecondaryWinding"].ToObject<double>();
-            transformer.TertiaryWinding = record["TertiaryWinding"].ToObject<double>();
+            // transformer.TertiaryWinding = record["TertiaryWinding"].ToObject<double>();
             transformer.Tap = record["Tap"].ToObject<double>();
             transformer.Spare = record["Spare"].ToObject<bool>();
         }

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -382,12 +382,7 @@ namespace SystemCenter.Controllers.OpenXDA
                         AssetKey = asset["AssetKey"].ToString() + "LineSegment",
                         Description = asset["Description"].ToString(),
                         AssetName = asset["AssetName"].ToString(),
-                        AssetTypeID = assetTypeID,
-                        R0 = asset["Segment"]["R0"].ToObject<double>(),
-                        X0 = asset["Segment"]["X0"].ToObject<double>(),
-                        R1 = asset["Segment"]["R1"].ToObject<double>(),
-                        X1 = asset["Segment"]["X1"].ToObject<double>(),
-                        Length = asset["Segment"]["Length"].ToObject<double>(),
+                        AssetTypeID = assetTypeID
                     };
                     lineSegment.AssetTypeID = connection.ExecuteScalar<int>("SELECT ID FROM AssetType WHERE Name = 'LineSegment'");
 

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -914,32 +914,29 @@ namespace SystemCenter.Controllers.OpenXDA
             capBank.PosReactanceTol = record["PosReactanceTol"].ToObject<double>();
             capBank.Nparalell = record["Nparalell"].ToObject<int>();
             capBank.Nseries = record["Nseries"].ToObject<int>();
-            /**
-            capBank.NSeriesGroup = record["NSeriesGroup"].ToObject<int>();
-            capBank.NParalellGroup = record["NParalellGroup"].ToObject<int>();
-            capBank.Fused = record["Fused"].ToObject<bool>();
-            capBank.VTratioBus = record["VTratioBus"].ToObject<double>();
-            capBank.NumberLVCaps = record["NumberLVCaps"].ToObject<int>();
-            capBank.NumberLVUnits = record["NumberLVUnits"].ToObject<int>();
-            capBank.LVKVAr = record["LVKVAr"].ToObject<double>(); 
-            capBank.LVKV = record["LVKV"].ToObject<double>();
-            capBank.LVNegReactanceTol = record["LVNegReactanceTol"].ToObject<double>();
-            capBank.LVPosReactanceTol = record["LVPosReactanceTol"].ToObject<double>();
-            */
+            capBank.NSeriesGroup = record.Value<int?>("NSeriesGroup") ?? 0;
+            capBank.NParalellGroup = record.Value<int?>("NParalellGroup") ?? 0;
+            capBank.Fused = record.Value<bool?>("Fused") ?? true;
+            capBank.VTratioBus = record.Value<double?>("VTratioBus") ?? 0;
+            capBank.NumberLVCaps = record.Value<int?>("NumberLVCaps") ?? 0;
+            capBank.NumberLVUnits = record.Value<int?>("NumberLVUnits") ?? 0;
+            capBank.LVKVAr = record.Value<double?>("LVKVAr") ?? 0;
+            capBank.LVKV = record.Value<double?>("LVKV") ?? 0;
+            capBank.LVNegReactanceTol = record.Value<double?>("LVNegReactanceTol") ?? 0;
+            capBank.LVPosReactanceTol = record.Value<double?>("LVPosReactanceTol") ?? 0;
+
             capBank.LowerXFRRatio = record["LowerXFRRatio"].ToObject<double>();
             capBank.Nshorted = record["Nshorted"].ToObject<double>();
             capBank.BlownFuses = record["BlownFuses"].ToObject<int>();
             capBank.BlownGroups = record["BlownGroups"].ToObject<int>();
-            /**
-            capBank.ShortedGroups = record["ShortedGroups"].ToObject<double>();
-            capBank.NLowerGroups = record["NLowerGroups"].ToObject<int>();
+            capBank.ShortedGroups = record.Value<double?>("ShortedGroups") ?? 0;
+            capBank.NLowerGroups = record.Value<int?>("NLowerGroups") ?? 0;
 
-            capBank.RelayPTRatioPrimary = record["RelayPTRatioPrimary"].ToObject<int>();
-            capBank.RelayPTRatioSecondary = record["RelayPTRatioSecondary"].ToObject<int>();
-            capBank.Sh = record["Sh"].ToObject<double>();
-            capBank.Rv = record["Rv"].ToObject<double>();
-            capBank.Rh = record["Rh"].ToObject<double>();
-            */
+            capBank.RelayPTRatioPrimary = record.Value<int?>("RelayPTRatioPrimary") ?? 0;
+            capBank.RelayPTRatioSecondary = record.Value<int?>("RelayPTRatioSecondary") ?? 0;
+            capBank.Sh = record.Value<double?>("Sh") ?? 0;
+            capBank.Rv = record.Value<double?>("Rv") ?? 0;
+            capBank.Rh = record.Value<double?>("Rh") ?? 0;
             capBank.Compensated = record["Compensated"].ToObject<bool>();
 
         }

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -966,10 +966,10 @@ namespace SystemCenter.Controllers.OpenXDA
             transformer.ThermalRating = record["ThermalRating"].ToObject<double>();
             transformer.PrimaryVoltageKV = record["PrimaryVoltageKV"].ToObject<double>();
             transformer.SecondaryVoltageKV = record["SecondaryVoltageKV"].ToObject<double>();
-            // transformer.TertiaryVoltageKV = record["TertiaryVoltageKV"].ToObject<double>();
+            transformer.TertiaryVoltageKV = record.Value<double?>("TertiaryVoltageKV") ?? 0;
             transformer.PrimaryWinding = record["PrimaryWinding"].ToObject<double>();
             transformer.SecondaryWinding = record["SecondaryWinding"].ToObject<double>();
-            // transformer.TertiaryWinding = record["TertiaryWinding"].ToObject<double>();
+            transformer.TertiaryWinding = record.Value<double?>("TertiaryWinding") ?? 0;
             transformer.Tap = record["Tap"].ToObject<double>();
             transformer.Spare = record["Spare"].ToObject<bool>();
         }

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
@@ -323,7 +323,6 @@ export namespace AssetAttributes {
                 errors.push('A valid Pickup Time Limit is required.')
             if ((asset as OpenXDA.Types.Breaker).TripCoilCondition == null || !AssetAttributes.isRealNumber((asset as OpenXDA.Types.Breaker).TripCoilCondition))
                 errors.push('A valid Trip Coil Condition Limit is required.')
-      
         }
 
         if (type == 'CapacitorBankRelay') {

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
@@ -257,6 +257,8 @@ export namespace AssetAttributes {
             record.ThermalRating = null;
             record.PrimaryVoltageKV = null;
             record.SecondaryVoltageKV = null;
+            record.TertiaryVoltageKV = null;
+            record.TertiaryWinding = null;
             record.Tap = null;
             return record
         }

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/AssetAttribute/Asset.tsx
@@ -200,6 +200,7 @@ export namespace AssetAttributes {
             record.TripTime = null;
             record.PickupTime = null;
             record.TripCoilCondition = null;
+            record.AirGapResistor = false;
             return record;
         }
         else if (type == 'Bus') {
@@ -320,7 +321,7 @@ export namespace AssetAttributes {
                 errors.push('A valid Pickup Time Limit is required.')
             if ((asset as OpenXDA.Types.Breaker).TripCoilCondition == null || !AssetAttributes.isRealNumber((asset as OpenXDA.Types.Breaker).TripCoilCondition))
                 errors.push('A valid Trip Coil Condition Limit is required.')
-           
+      
         }
 
         if (type == 'CapacitorBankRelay') {

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
@@ -337,7 +337,7 @@ const MeterAssetWindow = (props: IProps) => {
         else if (activeAsset.AssetType == 'Bus')
             return <BusAttributes NewEdit={newEdit} Asset={activeAsset} UpdateState={changeActiveAsset} />;
         else if (activeAsset.AssetType == 'CapacitorBankRelay')
-            return <CapBankRelayAttributes NewEdit={newEdit} Asset={activeAsset as OpenXDA.Types.CapBankRelay} UpdateState={changeActiveAsset}/>
+            return <CapBankRelayAttributes NewEdit={newEdit} Asset={activeAsset as OpenXDA.Types.CapBankRelay} UpdateState={changeActiveAsset} />
         else if (activeAsset.AssetType == 'CapacitorBank')
             return <CapBankAttributes NewEdit={newEdit} Asset={activeAsset as OpenXDA.Types.CapBank} UpdateState={changeActiveAsset} />;
         else if (activeAsset.AssetType == 'Line')

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/MeterAsset.tsx
@@ -27,6 +27,7 @@ import { Application, OpenXDA } from '@gpa-gemstone/application-typings';
 import BusAttributes from '../AssetAttribute/Bus';
 import BreakerAttributes from '../AssetAttribute/Breaker';
 import CapBankAttributes from '../AssetAttribute/CapBank';
+import CapBankRelayAttributes from '../AssetAttribute/CapBankRelay';
 import LineAttributes from '../AssetAttribute/Line';
 import TransformerAttributes from '../AssetAttribute/Transformer';
 import { useNavigate } from 'react-router-dom';
@@ -335,6 +336,8 @@ const MeterAssetWindow = (props: IProps) => {
             return <BreakerAttributes NewEdit={newEdit} Asset={activeAsset as OpenXDA.Types.Breaker} UpdateState={changeActiveAsset} ShowSpare={true} />;
         else if (activeAsset.AssetType == 'Bus')
             return <BusAttributes NewEdit={newEdit} Asset={activeAsset} UpdateState={changeActiveAsset} />;
+        else if (activeAsset.AssetType == 'CapacitorBankRelay')
+            return <CapBankRelayAttributes NewEdit={newEdit} Asset={activeAsset as OpenXDA.Types.CapBankRelay} UpdateState={changeActiveAsset}/>
         else if (activeAsset.AssetType == 'CapacitorBank')
             return <CapBankAttributes NewEdit={newEdit} Asset={activeAsset as OpenXDA.Types.CapBank} UpdateState={changeActiveAsset} />;
         else if (activeAsset.AssetType == 'Line')


### PR DESCRIPTION
Fixes problems related to adding Assets to Meter/Substations due to changes in Asset shape not being reflected in Asset-from-JSON helper functions, and oversights in switch statements leading to DERs being unpostable and CapBankRelay attributes not being shown.

---
**Jira Work Item(s)**

- SC-432
- SC-431 