### PR TITLE
SC-435 Update NMW to assign correct ConnectionPriority.

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
@@ -128,14 +128,14 @@ export default function AssetPage(props: IProps) {
         switch (newEditAsset.AssetType) {
             case 'Transformer':
                 return [
-                    { Id: "1", Label: "Primary Side"},
-                    { Id: "2", Label: "Secondary Side"},
-                    { Id: "3", Label: "Tertiary Side"}
+                    { Id: "0", Label: "Primary Side"},
+                    { Id: "1", Label: "Secondary Side"},
+                    { Id: "2", Label: "Tertiary Side"}
                 ];
             case 'Breaker':
                 return [
-                    { Id: "1", Label: "Bus Side" },
-                    { Id: "2", Label: "Line/XFR Side"},
+                    { Id: "0", Label: "Bus Side" },
+                    { Id: "1", Label: "Line/XFR Side"},
                 ];
             default:
                 return [];
@@ -189,9 +189,10 @@ export default function AssetPage(props: IProps) {
     }, [props.Assets]);
 
     React.useEffect(() => {
-        if (newEditAsset.AssetType === 'Transformer' || newEditAsset.AssetType === 'Breaker') setConnectionPriority(1);
-        else setConnectionPriority(0);
-    }, [newEditAsset.AssetType]);
+        if (tabs.length === 0) {
+            setConnectionPriority(0);
+        }
+    }, [tabs.length]);
 
     React.useEffect(() => {
         if (newEditAsset.AssetType == 'Breaker') {
@@ -595,7 +596,7 @@ export default function AssetPage(props: IProps) {
                                             CurrentTab={connectionPriority.toString()}
                                             SetTab={tabId => {
                                                 let newConPrio = parseInt(tabId);
-                                                if (isNaN(connectionPriority)) newConPrio = 1;
+                                                if (isNaN(newConPrio)) newConPrio = 0;
                                                 setConnectionPriority(newConPrio);
                                             }}
                                             Tabs={tabs}

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
@@ -188,6 +188,7 @@ export default function AssetPage(props: IProps) {
         setSelectedAssets(assetList);
     }, [props.Assets]);
 
+    // Reset to the first valid connectionPriority when the asset type changes.
     React.useEffect(() => {
             setConnectionPriority(0);
     }, [newEditAsset.AssetType]);

--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/NewMeterWizard/AssetPage.tsx
@@ -189,10 +189,8 @@ export default function AssetPage(props: IProps) {
     }, [props.Assets]);
 
     React.useEffect(() => {
-        if (tabs.length === 0) {
             setConnectionPriority(0);
-        }
-    }, [tabs.length]);
+    }, [newEditAsset.AssetType]);
 
     React.useEffect(() => {
         if (newEditAsset.AssetType == 'Breaker') {


### PR DESCRIPTION
ConnectionPriority indexes at 0, where NMW starts it at 1, which causes channels added to Transformer and Breaker Assets to be added at 1, 2, or 3 instead of 0, 1, or 2, meaning the channels are not using the correct voltages, etc.

Tested to ensure proper ConnectionPriority assignment.

---
**Jira Work Item(s)**

- [SC-435](https://gridprotectionalliance.atlassian.net/browse/SC-435)

[SC-435]: https://gridprotectionalliance.atlassian.net/browse/SC-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ