### PR TITLE
Allow Scale Channel multiplier replacement when both multipliers are set to 1.

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Meter/ChannelScaling/ChannelScalingForm.tsx
@@ -280,12 +280,11 @@ const ChannelScalingForm = (props: IProps) => {
             </div>
             <div className="card-footer">
                 <div className="btn-group mr-2">
-                    <button className={"btn btn-info pull-right" + ((multiplier.Voltage == 1 && multiplier.Current == 1) ? ' disabled' : '')} onClick={() => { if (multiplier.Voltage != 1 || multiplier.Current != 1) useReplacedMultiplier(); }}
+                    <button className={"btn btn-info pull-right" + (hasPermissions() ? '' : ' disabled')} onClick={() => { if (hasPermissions()) useReplacedMultiplier(); }}
                         onMouseEnter={() => setHover('Replace')} onMouseLeave={() => setHover('None')} data-tooltip={"rep"}
                     >Replace Multipliers</button>
-                    <ToolTip Show={hover == 'Replace' && (multiplier.Voltage == 1 && multiplier.Current == 1)} Position={'top'} Target={"rep"}>
-                        {!hasPermissions() ? <p>Your role does not have permission. Please contact your Administrator if you believe this to be in error.</p> : null}
-                        {hasPermissions() ? <p> There are no changes to be applied. </p> : null}
+                    <ToolTip Show={hover == 'Replace' && !hasPermissions()} Position={'top'} Target={"rep"}>
+                        <p>Your role does not have permission. Please contact your Administrator if you believe this to be in error.</p>
                     </ToolTip>
                 </div>
                 <div className="btn-group mr-2">


### PR DESCRIPTION
Allow users with permissions to replace meter channel scaling multipliers when both multipliers are set to 1.

The guard preventing users from replacing multipliers when both are set to 1 seems to have been to prevent users without permissions from replacing multipliers, since the multiplier fields are set to 1 by default and changes are disabled for users without permissions. That is why this code change explicitly checks permissions before replacing multipliers, instead of checking to see if fields remain unchanged.

---
**Jira Work Item(s)**

- SC-425