### PR TITLE
switch ModelController PagedSearch overrides to derive RecordsPerPage…

### DIFF
--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Assets/OpenXDAAssetController.cs
@@ -71,7 +71,7 @@ namespace SystemCenter.Controllers.OpenXDA
             if (!GetAuthCheck())
                 return Unauthorized();
 
-            int recordsPerPage = Take ?? 50;
+            int recordsPerPage = PageSize ?? 50;
 
             PagedResults results = new PagedResults();
 
@@ -164,7 +164,7 @@ namespace SystemCenter.Controllers.OpenXDA
                 {
                     try
                     {
-                        int recordsPerPage = Take ?? 50;
+                        int recordsPerPage = PageSize ?? 50;
 
                         string[] sortFields = { "AssetKey", "Name", "Make", "Model" };
 
@@ -204,7 +204,7 @@ namespace SystemCenter.Controllers.OpenXDA
                 {
                     try
                     {
-                        int recordsPerPage = Take ?? 50;
+                        int recordsPerPage = PageSize ?? 50;
 
                         string[] sortFields = { "AssetName", "AssetKey", "Name" };
 

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/Meters/OpenXDAMeterConfigurationController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/Meters/OpenXDAMeterConfigurationController.cs
@@ -45,7 +45,7 @@ namespace SystemCenter.Controllers.OpenXDA
         [HttpGet, Route("Meter/{meterID:int}/{page:int}")]
         public IHttpActionResult GetMeterConfigurationsForMeter(int meterID, int page)
         {
-            int recordsPerPage = 50;
+            int recordsPerPage = PageSize ?? 50;
             if (GetRoles == string.Empty || User.IsInRole(GetRoles))
             {
                 using (AdoDataConnection connection = new AdoDataConnection(Connection))
@@ -93,7 +93,7 @@ namespace SystemCenter.Controllers.OpenXDA
         [HttpGet, Route("{meterConfigurationID:int}/FilesProcessed/{page:int}")]
         public IHttpActionResult GetFilesProcessedForMeterConfigurations(int meterConfigurationID, int page)
         {
-            int recordsPerPage = 50;
+            int recordsPerPage = PageSize ?? 50;
             if (GetRoles == string.Empty || User.IsInRole(GetRoles))
             {
                 using (AdoDataConnection connection = new AdoDataConnection(Connection))

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/OpenXDAControllers.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/OpenXDAControllers.cs
@@ -111,7 +111,7 @@ namespace SystemCenter.Controllers.OpenXDA
             if (!GetAuthCheck())
                 return Unauthorized();
 
-            int recordsPerPage = Take ?? 50;
+            int recordsPerPage = PageSize ?? 50;
 
             List<object> param = new();
 

--- a/Source/Applications/SystemCenter/Controllers/OpenXDA/OpenXDALocationController.cs
+++ b/Source/Applications/SystemCenter/Controllers/OpenXDA/OpenXDALocationController.cs
@@ -217,7 +217,7 @@ namespace SystemCenter.Controllers.OpenXDA
             if (!string.IsNullOrEmpty(GetRoles) && User.IsInRole(GetRoles))
                 return Unauthorized();
 
-            int recordsPerPage = 50;
+            int recordsPerPage = PageSize ?? 50;
             using (AdoDataConnection connection = new AdoDataConnection(Connection))
             {
                 int totalRecords = connection.ExecuteScalar<int>($@"
@@ -256,7 +256,7 @@ namespace SystemCenter.Controllers.OpenXDA
         [HttpGet, Route("{locationID:int}/Assets/{page:int}/{asc:int}/{orderBy}")]
         public IHttpActionResult GetAssetsForLocation(int locationID, int page, int asc, string orderBy)
         {
-            int recordsPerPage = 50;
+            int recordsPerPage = PageSize ?? 50;
 
             if (!string.IsNullOrEmpty(GetRoles) && User.IsInRole(GetRoles))
                 return Unauthorized();
@@ -323,7 +323,7 @@ namespace SystemCenter.Controllers.OpenXDA
                         if (Directory.Exists(Path.Combine(path, key)))
                         {
                                 IEnumerable<string> imagePaths = Directory.GetFiles(Path.Combine(path, key)).Select(fp => new FileInfo(fp).Name);
-                                return Ok(PageImagePaths(imagePaths, page, Take ?? 50));
+                                return Ok(PageImagePaths(imagePaths, page, PageSize ?? 50));
                         }
                         else
                             return Ok(new PagedResults()
@@ -331,7 +331,7 @@ namespace SystemCenter.Controllers.OpenXDA
                                 Data = JsonConvert.SerializeObject(new string[0]),
                                 TotalRecords = 0,
                                 NumberOfPages = 0,
-                                RecordsPerPage = Take ?? 50
+                                RecordsPerPage = PageSize ?? 50
                             });
                     }
                 else

--- a/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
+++ b/Source/Applications/SystemCenter/Controllers/SystemCenter/SystemCenterController.cs
@@ -633,7 +633,7 @@ namespace SystemCenter.Controllers
             {
                 string orderByExpression = DefaultSort;
 
-                int recordsPerPage = Take ?? 50;
+                int recordsPerPage = PageSize ?? 50;
 
                 if (sort != null && sort != string.Empty)
                     orderByExpression = $"{sort} {(ascending == 1 ? "ASC" : "DESC")}";

--- a/Source/Applications/SystemCenter/Model/DataFile.cs
+++ b/Source/Applications/SystemCenter/Model/DataFile.cs
@@ -321,7 +321,7 @@ namespace SystemCenter.Model
                 }).ToArray();
 
             int recordCount = CountSearchResults(postData);
-            int recordPerPage = Take ?? 50;
+            int recordPerPage = PageSize ?? 50;
             return Ok(new PagedResults()
             {
                 Data = JsonConvert.SerializeObject(results),
@@ -360,7 +360,7 @@ namespace SystemCenter.Model
                 }).ToArray();
 
             int recordCount = CountSearchResults(postData);
-            int recordPerPage = Take ?? 50;
+            int recordPerPage = PageSize ?? 50;
             return Ok(new PagedResults()
             {
                 Data = JsonConvert.SerializeObject(results),
@@ -398,7 +398,7 @@ namespace SystemCenter.Model
                 }).ToArray();
 
             int recordCount = CountSearchResults(postData);
-            int recordPerPage = Take ?? 50;
+            int recordPerPage = PageSize ?? 50;
             return Ok(new PagedResults()
             {
                 Data = JsonConvert.SerializeObject(results),

--- a/Source/Applications/SystemCenter/Model/DeviceHealthReport.cs
+++ b/Source/Applications/SystemCenter/Model/DeviceHealthReport.cs
@@ -111,7 +111,6 @@ namespace SystemCenter.Model
     [RoutePrefix("api/DeviceHealthReport")]
     public class DeviceHealthReportController : ModelController<DeviceHealthReport>
     {
-        public int PagingAmount { get; set; } = 50;
         public class DailyStatisticsRecord
         {
             [PrimaryKey(true)]
@@ -144,7 +143,7 @@ namespace SystemCenter.Model
         {
             PagedResults pagedReports = new()
             {
-                RecordsPerPage = 50
+                RecordsPerPage = PageSize ?? 50
             };
 
             PostData openMicRequestBody = new()

--- a/Source/Applications/SystemCenter/Model/Node.cs
+++ b/Source/Applications/SystemCenter/Model/Node.cs
@@ -30,7 +30,7 @@ using openXDA.Model;
 
 namespace SystemCenter.Model
 {
-    [TableName("Node"), ReturnLimit(50),
+    [TableName("Node"),
      CustomView(@"
     SELECT 
 	    Node.ID,

--- a/Source/Applications/SystemCenter/Model/Security/SecurityGroup.cs
+++ b/Source/Applications/SystemCenter/Model/Security/SecurityGroup.cs
@@ -274,7 +274,7 @@ namespace SystemCenter.Model.Security
 
             if (page is int p) // page manually, because filtering post-search requires it.
             {
-                int recordsPerPage = Take ?? 50;
+                int recordsPerPage = PageSize ?? 50;
                 DataRow[] rows = dataTable.AsEnumerable()
                     .Skip((p) * recordsPerPage)
                     .Take(recordsPerPage)

--- a/Source/Applications/SystemCenter/Model/Security/UserAccount.cs
+++ b/Source/Applications/SystemCenter/Model/Security/UserAccount.cs
@@ -242,7 +242,7 @@ namespace SystemCenter.Model.Security
 
             if (page is int p)// page manually, because filtering post-search requires it.
             {
-                int recordsPerPage = Take ?? 50;
+                int recordsPerPage = PageSize ?? 50;
                 DataRow[] rows = dataTable.AsEnumerable()
                     .Skip((p) * recordsPerPage)
                     .Take(recordsPerPage)

--- a/Source/Applications/SystemCenterNotification/Controllers/EmailTypeController.cs
+++ b/Source/Applications/SystemCenterNotification/Controllers/EmailTypeController.cs
@@ -440,7 +440,7 @@ namespace SystemCenter.Notifications.Controllers
         public IHttpActionResult SentEmailTimelinePaged([FromBody] PostData postData, [FromUri] int sentEmailID, [FromUri] int page)
         {
             PagedResults pagedResults = new PagedResults();
-            int recordsPerPage = Take ?? 50;
+            int recordsPerPage = PageSize ?? 50;
 
             List<TimelineItem> timeline = GetEmailTimeline(postData, sentEmailID);
             int totalRecords = timeline.Count;


### PR DESCRIPTION
Changes `PagedSearch` overrides to use the new `ModelController` property `PageSize` to determine `RecordsPerPage` instead of `Take`.

---
**The following PR(s) need to be merged prior to this one:**

- [] (https://github.com/GridProtectionAlliance/gsf/pull/573)