### PR TITLE
Reset New Substation Modal when closed

### DIFF
--- a/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/ByLocation.tsx
+++ b/Source/Applications/SystemCenter/wwwroot/Scripts/TSX/SystemCenter/Location/ByLocation.tsx
@@ -279,6 +279,7 @@ const ByLocation: Application.Types.iByComponent = (props) => {
                     if (conf)
                         dispatch(ByLocationSlice.DBAction({ verb: "POST", record: newLocation }))
                     setShowNew(false);
+                    setNewLocation(getNewLocation());
                 }}
                 ConfirmShowToolTip={newLocationErrors.length > 0}
                 ConfirmToolTipContent={


### PR DESCRIPTION
Reset the values of the new substation form when the modal is closed, whether or not it is posted.
